### PR TITLE
Adding .uvoptx & .uvprojx to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ Objects/
 *.ewt
 *.custom_argvars
 *.project
+*.ewd
+*.ewp

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ Objects/
 *.project
 *.ewd
 *.ewp
+*.uvoptx
+*.uvprojx

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,7 @@ Objects/
 *.ewt
 *.custom_argvars
 *.project
+*.uvoptx
+*.uvprojx
 
 	


### PR DESCRIPTION
Avoids unnecessary oversight of project build files by Git when using Keil uVision.