### PR TITLE
adjust terminal output of calibration data

### DIFF
--- a/examples/AD5940_BATImpedance/BATImpedance.c
+++ b/examples/AD5940_BATImpedance/BATImpedance.c
@@ -642,7 +642,7 @@ AD5940Err AppBATMeasureRCAL(void)
 			AppBATISR(buff, &temp);
 			AppBATCfg.RcalVoltTable[i][0] = AppBATCfg.RcalVolt.Real;
 			AppBATCfg.RcalVoltTable[i][1] = AppBATCfg.RcalVolt.Image;
-			printf(" RcalVolt:(%f,%f)\n",  AppBATCfg.RcalVoltTable[i][0], AppBATCfg.RcalVoltTable[i][1]);
+			printf(" RcalVolt (bits_real,bits_imag),%.0f,%.0f,\n",  AppBATCfg.RcalVoltTable[i][0], AppBATCfg.RcalVoltTable[i][1]);
 			AD5940_Delay10us(10000);
     }
 		AppBATCfg.RcalVolt.Real = AppBATCfg.RcalVoltTable[0][0];


### PR DESCRIPTION
As per:
https://ez.analog.com/reference-designs/f/q-a/579883/cn0510-calibration-reporting-integers/520545

The calibration being reported in the BAT_Impedance sample code is confusing in its current format.

It's also a bit of a pain to parse.

Please consider the following output string which reports the bits as integers and parses the numbers of interest with commas