### PR TITLE
Bat impedance refactor ad5940lib

### DIFF
--- a/examples/AD5940_BATImpedance/AD5940Main.c
+++ b/examples/AD5940_BATImpedance/AD5940Main.c
@@ -101,8 +101,8 @@ void AD5940BATStructInit(void)
 	
 	pBATCfg->SweepCfg.SweepEn = bTRUE;			/* Set to bTRUE to enable sweep function */
 	pBATCfg->SweepCfg.SweepStart = 1.0f;		/* Start sweep at 1Hz  */
-	pBATCfg->SweepCfg.SweepStop = 1000.0f;	/* Finish sweep at 1000Hz */
-	pBATCfg->SweepCfg.SweepPoints = 20;			/* 100 frequencies in the sweep */
+	pBATCfg->SweepCfg.SweepStop = 50000.0f;	/* Finish sweep at 1000Hz */
+	pBATCfg->SweepCfg.SweepPoints = 50;			/* 100 frequencies in the sweep */
 	pBATCfg->SweepCfg.SweepLog = bTRUE;			/* Set to bTRUE to use LOG scale. Set bFALSE to use linear scale */
 	
 }

--- a/examples/AD5940_BATImpedance/ADICUP3029/AD5940_BATImpedance.ewp
+++ b/examples/AD5940_BATImpedance/ADICUP3029/AD5940_BATImpedance.ewp
@@ -352,6 +352,7 @@
                 <option>
                     <name>CCIncludePath2</name>
                     <state>$PROJ_DIR$\</state>
+                    <state>$PROJ_DIR$\..\</state>
                     <state>$PROJ_DIR$\..\..\ad5940lib</state>
                     <state>$CMSIS_PACK_DEVICE_INCLUDES$</state>
                     <state>$CMSIS_PACK_INCLUDES$</state>

--- a/examples/AD5940_BATImpedance/ADICUP3029/AD5940_BATImpedance.ewp
+++ b/examples/AD5940_BATImpedance/ADICUP3029/AD5940_BATImpedance.ewp
@@ -2086,7 +2086,7 @@
     <group>
         <name>AD5940Lib</name>
         <file>
-            <name>$PROJ_DIR$\..\..\ad5940lib\ad5940.c</name>
+            <name>$PROJ_DIR$\..\ad5940.c</name>
         </file>
         <file>
             <name>$PROJ_DIR$\ADICUP3029Port.c</name>

--- a/examples/AD5940_BATImpedance/ad5940.c
+++ b/examples/AD5940_BATImpedance/ad5940.c
@@ -1,0 +1,4392 @@
+/**  
+ * @file       ad5940.c
+ * @brief      AD5940 library. This file contains all AD5940 library functions. 
+ * @author     ADI
+ * @date       March 2019
+ * @par Revision History:
+ * 
+ * Copyright (c) 2017-2019 Analog Devices, Inc. All Rights Reserved.
+ * 
+ * This software is proprietary to Analog Devices, Inc. and its licensors.
+ * By using this software you agree to the terms of the associated
+ * Analog Devices Software License Agreement.
+**/
+#include "ad5940.h"
+
+/*! \mainpage AD5940 Library Introduction
+ * 
+ * ![AD5940 EVAL Board](https://www.analog.com/-/media/analog/en/evaluation-board-images/images/eval-ad5940elcztop-web.gif?h=500&thn=1&hash=1F38F7CC1002894616F74D316365C0A2631C432B "ADI logo") 
+ * 
+ * # Introduction
+ *
+ * The documentation is for AD594x library and examples.
+ * 
+ * # Manual Structure
+ *
+ * @ref AD5940_Library                                                      
+ *  - @ref AD5940_Functions                                                 
+ *  - @ref TypeDefinitions                                                    
+ * @ref AD5940_Standard_Examples                                            
+ * @ref AD5940_System_Examples	                                            
+ * 
+ * # How to Use It
+ *  We provide examples that can directly run out of box.
+ *  The files can generally be separated to three parts:
+ *    - AD5940 Library files. ad5940.c and ad5940.h specifically. These two files are shared among all examples.
+ *    - AD5940 System Examples. The system examples mean system level application like measuring impedance.
+ *    - Standard examples. These include basic block level examples like ADC. It shows how to setup and use one specific block.
+ * 
+ * ## Requirements to run these examples
+ *  ### Hardware
+ *  - Use EVAL_AD5940 or EVAL_AD5941. The default MCU board we used is ADICUP3029. We also provide project for ST NUCLEO board.
+ *  - Or use EVAL_ADuCM355
+ *  ### Software
+ *  - Pull all the source file from [GitHub](https://github.com/analogdevicesinc/ad5940-examples.git)
+ *  - CMSIS pack that related to specific MCU. This normally is done by IDE you use.
+ * 
+ * ## Materials
+ *      Please use this library together with following materials.
+ *      - [AD5940 Data Sheet](https://www.analog.com/media/en/technical-documentation/data-sheets/AD5940.pdf)
+ *      - [AD5940 Eval Board](https://www.analog.com/en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/EVAL-AD5940.html)
+ *
+ */
+
+/* Remove below variables after AD594x is released. */
+static BoolFlag bIsS2silicon = bFALSE;
+
+/* Declare of SPI functions used to read/write registers */
+#ifndef CHIPSEL_M355
+static uint32_t AD5940_SPIReadReg(uint16_t RegAddr);
+static void AD5940_SPIWriteReg(uint16_t RegAddr, uint32_t RegData);
+#else
+static uint32_t AD5940_D2DReadReg(uint16_t RegAddr);
+static void AD5940_D2DWriteReg(uint16_t RegAddr, uint32_t RegData);
+#endif
+
+/** 
+ * @addtogroup AD5940_Library
+ *  The library functions, structures and constants.
+ * @{
+ *    @defgroup AD5940_Functions
+ *    @{
+ *        @defgroup Function_Helpers
+ *        @brief The functions with no hardware access. They are helpers.
+ *        @{
+ *            @defgroup Sequencer_Generator_Functions
+ *            @brief The set of function used to track all register read and write once it's enabled. It can translate register write operation to sequencer commands. 
+ *            @{
+*/
+
+#define SEQUENCE_GENERATOR  /*!< Build sequence generator part in to lib. Comment this line to remove this feature  */
+
+#ifdef SEQUENCE_GENERATOR
+/**
+ * Structure used to store register information(address and its data) 
+ * */
+typedef struct
+{
+  uint32_t RegAddr  :8;   /**< 8bit address is enough for sequencer */
+  uint32_t RegValue :24;  /**< Reg data is limited to 24bit by sequencer  */
+}SEQGenRegInfo_Type;
+
+/**
+ * Sequencer generator data base.
+*/
+struct
+{
+  BoolFlag EngineStart;         /**< Flag to mark start of the generator */
+  uint32_t BufferSize;          /**< Total buffer size */
+
+  uint32_t *pSeqBuff;           /**< The buffer for sequence generator(both sequences and RegInfo) */
+  uint32_t SeqLen;              /**< Generated sequence length till now */
+  SEQGenRegInfo_Type *pRegInfo; /**< Pointer to buffer where stores register info */
+  uint32_t RegCount;            /**< The count of register info available in buffer *pRegInfo. */
+  AD5940Err LastError;          /**< The last error message. */
+}SeqGenDB;  /* Data base of Seq Generator */
+
+/**
+ * @brief Manually input a command to sequencer generator.
+ * @param CmdWord: The 32-bit width sequencer command word. @ref Sequencer_Helper can be used to generate commands.
+ * @return None;
+*/
+void AD5940_SEQGenInsert(uint32_t CmdWord)
+{
+  uint32_t temp;
+  temp  = SeqGenDB.RegCount + SeqGenDB.SeqLen;
+  /* Generate Sequence command */
+  if(temp < SeqGenDB.BufferSize)
+  {
+    SeqGenDB.pSeqBuff[SeqGenDB.SeqLen] = CmdWord;
+    SeqGenDB.SeqLen ++;
+  }
+  else  /* There is no buffer */
+    SeqGenDB.LastError = AD5940ERR_BUFF;
+}
+
+/**
+ * @brief Search data-base to get current register value.
+ * @param RegAddr: The register address.
+ * @param pIndex: Pointer to a variable that used to store index of found register-info.
+ * @return Return AD5940ERR_OK if register found in data-base. Otherwise return AD5940ERR_SEQREG.
+*/
+static AD5940Err AD5940_SEQGenSearchReg(uint32_t RegAddr, uint32_t *pIndex)
+{
+  uint32_t i;
+
+  RegAddr = (RegAddr>>2)&0xff;
+  for(i=0;i<SeqGenDB.RegCount;i++)
+  {
+    if(RegAddr == SeqGenDB.pRegInfo[i].RegAddr)
+    {
+      *pIndex = i;
+      return AD5940ERR_OK;
+    }
+  }
+  return AD5940ERR_SEQREG;
+}
+
+/**
+ * @brief Get the register default value by SPI read. This function requires AD5940 is in active state, otherwise we cannot get the default register value.
+ * @param RegAddr: The register address.
+ * @param pRegData: Pointer to a variable to store register default value.
+ * @return Return AD5940ERR_OK.
+*/
+static AD5940Err AD5940_SEQGenGetRegDefault(uint32_t RegAddr, uint32_t *pRegData)
+{
+#ifdef CHIPSEL_M355
+  *pRegData = AD5940_D2DReadReg(RegAddr);
+#else
+  *pRegData = AD5940_SPIReadReg(RegAddr);
+#endif
+  return AD5940ERR_OK;
+}
+
+/**
+ * @brief Record the current register info to data-base. Update LastError if there is error.
+ * @param RegAddr: The register address.
+ * @param RegData: The register data
+ * @return Return None.
+*/
+static void AD5940_SEQRegInfoInsert(uint16_t RegAddr, uint32_t RegData)
+{
+  uint32_t temp;
+  temp = SeqGenDB.RegCount + SeqGenDB.SeqLen;
+  
+  if(temp < SeqGenDB.BufferSize)
+  {
+    SeqGenDB.pRegInfo --; /* Move back */
+    SeqGenDB.pRegInfo[0].RegAddr = (RegAddr>>2)&0xff;
+    SeqGenDB.pRegInfo[0].RegValue = RegData&0x00ffffff;
+    SeqGenDB.RegCount ++;
+  }
+  else  /* There is no more buffer  */
+  {
+    SeqGenDB.LastError = AD5940ERR_BUFF;
+  }
+}
+
+/**
+ * @brief Get current register value. If we have record in data-base, read it. Otherwise, return the register default value.
+ * @param RegAddr: The register address.
+ * @return Return register value.
+*/
+static uint32_t AD5940_SEQReadReg(uint16_t RegAddr)
+{
+  uint32_t RegIndex, RegData;
+  
+  if(AD5940_SEQGenSearchReg(RegAddr, &RegIndex) != AD5940ERR_OK)
+  {
+    /* There is no record in data-base, read the default value. */
+    AD5940_SEQGenGetRegDefault(RegAddr, &RegData);
+    AD5940_SEQRegInfoInsert(RegAddr, RegData);
+  }
+  else
+  {
+    /* return the current register value stored in data-base */
+    RegData = SeqGenDB.pRegInfo[RegIndex].RegValue;
+  }
+
+  return RegData;
+}
+
+/**
+ * @brief Generate a sequencer command to write register. If the register address is out of range, it won't generate a command.
+ *        This function will also update the register-info in data-base to record current register value.
+ * @param RegAddr: The register address.
+ * @param RegData: The register value.
+ * @return Return None.
+*/
+static void AD5940_SEQWriteReg(uint16_t RegAddr, uint32_t RegData)
+{
+  uint32_t RegIndex;
+  
+  if(RegAddr > 0x21ff)
+  {
+    SeqGenDB.LastError = AD5940ERR_ADDROR;  /* address out of range  */
+    return;
+  }
+
+  if(AD5940_SEQGenSearchReg(RegAddr, &RegIndex) == AD5940ERR_OK)
+  {
+    /* Store register value */
+    SeqGenDB.pRegInfo[RegIndex].RegValue = RegData;
+    /* Generate Sequence command */
+    AD5940_SEQGenInsert(SEQ_WR(RegAddr, RegData));
+  }
+  else
+  {
+    AD5940_SEQRegInfoInsert(RegAddr, RegData);
+    /* Generate Sequence command */
+    AD5940_SEQGenInsert(SEQ_WR(RegAddr, RegData));
+  }
+}
+
+/**
+ * @brief Initialize sequencer generator with specified buffer.
+ *        The buffer is used to store sequencer generated and record register value changes.
+ *        The command is stored from start address of buffer while register value is stored from end of buffer.
+ *    Buffer[0] : First sequencer command;
+ *    Buffer[1] : Second Sequencer command;
+ *    ...
+ *    Buffer[Last-1]: The second register value record.
+ *    Buffer[Last]: The first register value record.
+ * @param pBuffer: Pointer to the buffer.
+ * @param BufferSize: The buffer length.
+ * @return Return None.
+*/
+void AD5940_SEQGenInit(uint32_t *pBuffer, uint32_t BufferSize)
+{
+  if(BufferSize < 2) return;
+  SeqGenDB.BufferSize = BufferSize;
+  SeqGenDB.pSeqBuff = pBuffer;
+  SeqGenDB.pRegInfo = (SEQGenRegInfo_Type*)pBuffer + BufferSize - 1; /* Point to the last element in buffer */
+  SeqGenDB.SeqLen = 0;
+
+  SeqGenDB.RegCount = 0;
+  SeqGenDB.LastError = AD5940ERR_OK;
+  SeqGenDB.EngineStart = bFALSE;
+}
+
+/**
+ * @brief Get sequencer command generated.
+ * @param ppSeqCmd: Pointer to a variable(pointer) used to store the pointer to generated sequencer command.
+ * @param pSeqLen: Pointer to a variable that used to store how many commands available in buffer.
+ * @return Return lasterror.
+*/
+AD5940Err AD5940_SEQGenFetchSeq(const uint32_t **ppSeqCmd, uint32_t *pSeqLen)
+{
+  AD5940Err lasterror;
+
+  if(ppSeqCmd)
+    *ppSeqCmd = SeqGenDB.pSeqBuff;  
+  if(pSeqLen)
+    *pSeqLen = SeqGenDB.SeqLen;
+
+  //SeqGenDB.SeqLen = 0;  /* Start a new sequence */
+  lasterror = SeqGenDB.LastError;
+  //SeqGenDB.LastError = AD5940ERR_OK;  /* Clear error message */
+  return lasterror;
+}
+
+/**
+ * @brief Start or stop the sequencer generator. Once started, the register write will be recorded to sequencer generator.
+ *        Once it's disabled, the register write is written to AD5940 directly by SPI bus.
+ * @param bFlag: Enable or disable sequencer generator.
+ * @return Return None.
+*/
+void AD5940_SEQGenCtrl(BoolFlag bFlag)
+{
+  if(bFlag == bFALSE) /* Disable sequence generator */
+  {
+    SeqGenDB.EngineStart = bFALSE;
+  }
+  else
+  {
+    SeqGenDB.SeqLen = 0;
+    SeqGenDB.LastError = AD5940ERR_OK;  /* Clear error message */
+    SeqGenDB.EngineStart = bTRUE;
+  }
+}
+
+/**
+ * @brief Calculate the number of cycles in the sequence
+ * @return Return Number of ACLK Cycles that a generated sequence will take.
+*/
+uint32_t AD5940_SEQCycleTime(void)
+{
+  uint32_t i, Cycles, Cmd;  
+  Cycles = 0;
+  for(i=0;i<SeqGenDB.RegCount;i++)
+  {
+    Cmd = (SeqGenDB.pSeqBuff[i]  >> 30) & 0x3;
+    if (Cmd & 0x2)
+    {
+      /* A write command */
+      Cycles += 1;
+    }
+    else
+    {
+      if (Cmd & 0x1)
+      {
+        /* Timeout Command */    
+        Cycles += 1;
+      }
+      else
+        {
+          /* Wait command */
+          Cycles += SeqGenDB.pSeqBuff[i] & 0x3FFFFFFF;
+        }
+    }
+  } 
+  return Cycles;  
+}
+#endif
+/**
+ * @} Sequencer_Generator_Functions
+*/
+
+/**
+ * Check if an uint8_t value exist in table.
+*/
+static int32_t _is_value_in_table(uint8_t value, const uint8_t *table, uint8_t len, uint8_t *index)
+{
+  for(int i=0; i<len; i++)
+  {
+    if(value == table[i])
+    {
+      *index = i;
+      return bTRUE;
+    }
+  }
+  return bFALSE;
+}
+
+/**
+ * @brief return if the SINC3/SINC2 combination is available for notch 50Hz filter.
+ *        If it's not availabe, hardware automatically bypass Notch even if it's enabled.
+ * @param pFilterInfo the filter configuration, only need sinc2/sinc3 osr and adc data rate information.
+ * @return return bTRUE if notch 50Hz filter is available.
+*/
+BoolFlag AD5940_Notch50HzAvailable(ADCFilterCfg_Type *pFilterInfo, uint8_t *dl)
+{
+  if((pFilterInfo->ADCRate == ADCRATE_800KHZ && pFilterInfo->ADCSinc3Osr == ADCSINC3OSR_2)||\
+      (pFilterInfo->ADCRate == ADCRATE_1P6MHZ && pFilterInfo->ADCSinc3Osr != ADCSINC3OSR_2))
+  {
+    //this combination suits for filter:
+    //SINC3 OSR2, for 800kSPS
+    //and SINC3 OSR4 and OSR5 for 1.6MSPS,
+    const uint8_t available_sinc2_osr[] = {ADCSINC2OSR_533, ADCSINC2OSR_667,ADCSINC2OSR_800, ADCSINC2OSR_889, ADCSINC2OSR_1333};
+    const uint8_t dl_50Hz[] = {15,12,10,9,6};
+    uint8_t index;
+    if(_is_value_in_table(pFilterInfo->ADCSinc2Osr, available_sinc2_osr, sizeof(available_sinc2_osr), &index))
+    {
+      *dl = dl_50Hz[index];
+      return bTRUE;
+    }
+  }
+  else if(pFilterInfo->ADCRate == ADCRATE_1P6MHZ && pFilterInfo->ADCSinc3Osr == ADCSINC3OSR_2)
+  {
+    //this combination suits for filter:
+    //SINC3 OSR2 for 1.6MSPS
+    const uint8_t available_sinc2_osr[] = {ADCSINC2OSR_889, ADCSINC2OSR_1067, ADCSINC2OSR_1333};
+    const uint8_t dl_50Hz[] = {18,15,12};
+    uint8_t index;
+    if(_is_value_in_table(pFilterInfo->ADCSinc2Osr, available_sinc2_osr, sizeof(available_sinc2_osr), &index))
+    {
+      *dl = dl_50Hz[index];
+      return bTRUE;
+    }
+  }
+  else if(pFilterInfo->ADCRate == ADCRATE_800KHZ && pFilterInfo->ADCSinc3Osr != ADCSINC3OSR_2)
+  {
+    //this combination suits for filter:
+    //SINC3 OSR4 and OSR5 for 800kSPS,
+    const uint8_t available_sinc2_osr[] = {ADCSINC2OSR_178, ADCSINC2OSR_267, ADCSINC2OSR_533, ADCSINC2OSR_640,\
+                                    ADCSINC2OSR_800, ADCSINC2OSR_1067};
+    const uint8_t dl_50Hz[] = {18,12,6,5,4,3};
+    uint8_t index;
+    if(_is_value_in_table(pFilterInfo->ADCSinc2Osr, available_sinc2_osr, sizeof(available_sinc2_osr), &index))
+    {
+      *dl = dl_50Hz[index];
+      return bTRUE;
+    }
+  }
+  *dl = 0;
+  return bFALSE;
+}
+
+/**
+ * @brief return if the SINC3/SINC2 combination is available for notch 60Hz filter.
+ *        If it's not availabe, hardware automatically bypass Notch even if it's enabled.
+ * @param pFilterInfo the filter configuration, need sinc2/sinc3 osr and adc data rate information.
+ * @return return bTRUE if notch 60Hz filter is available.
+*/
+BoolFlag AD5940_Notch60HzAvailable(ADCFilterCfg_Type *pFilterInfo, uint8_t *dl)
+{
+  if((pFilterInfo->ADCRate == ADCRATE_800KHZ && pFilterInfo->ADCSinc3Osr == ADCSINC3OSR_2)||\
+      (pFilterInfo->ADCRate == ADCRATE_1P6MHZ && pFilterInfo->ADCSinc3Osr != ADCSINC3OSR_2))
+  {
+    //this combination suits for filter:
+    //SINC3 OSR2, for 800kSPS
+    //and SINC3 OSR4 and OSR5 for 1.6MSPS,
+    const uint8_t available_sinc2_osr[] = {ADCSINC2OSR_667, ADCSINC2OSR_1333};
+    const uint8_t dl_60Hz[] = {10,5};
+    uint8_t index;
+    if(_is_value_in_table(pFilterInfo->ADCSinc2Osr, available_sinc2_osr, sizeof(available_sinc2_osr), &index))
+    {
+      *dl = dl_60Hz[index];
+      return bTRUE;
+    }
+  }
+  else if(pFilterInfo->ADCRate == ADCRATE_1P6MHZ && pFilterInfo->ADCSinc3Osr == ADCSINC3OSR_2)
+  {
+    //this combination suits for filter:
+    //SINC3 OSR2 for 1.6MSPS
+    const uint8_t available_sinc2_osr[] = {ADCSINC2OSR_889, ADCSINC2OSR_1333};
+    const uint8_t dl_60Hz[] = {15,10};
+    uint8_t index;
+    if(_is_value_in_table(pFilterInfo->ADCSinc2Osr, available_sinc2_osr, sizeof(available_sinc2_osr), &index))
+    {
+      *dl = dl_60Hz[index];
+      return bTRUE;
+    }
+  }
+  else if(pFilterInfo->ADCRate == ADCRATE_800KHZ && pFilterInfo->ADCSinc3Osr != ADCSINC3OSR_2)
+  {
+    //this combination suits for filter:
+    //SINC3 OSR4 and OSR5 for 800kSPS,
+    const uint8_t available_sinc2_osr[] = {ADCSINC2OSR_178, ADCSINC2OSR_267, ADCSINC2OSR_533, ADCSINC2OSR_667,\
+                                    ADCSINC2OSR_889, ADCSINC2OSR_1333};
+    const uint8_t dl_60Hz[] = {15,10,5,4,3,2};
+    uint8_t index;
+    if(_is_value_in_table(pFilterInfo->ADCSinc2Osr, available_sinc2_osr, sizeof(available_sinc2_osr), &index))
+    {
+      *dl = dl_60Hz[index];
+      return bTRUE;
+    }
+  }
+  *dl = 0;
+  return bFALSE;
+}
+
+/**
+ * @brief Calculate how many clocks are needed in sequencer wait command to generate required number of data from filter output.
+ * @note When measurement is done, it's recommend to disable blocks like ADCPWR, ADCCNV, SINC2, DFT etc. If blocks remain powered up,
+ *       they may need less clocks to generate required number of output. Use function @ref AD5940_AFECtrlS to control these blocks.
+ * @param pFilterInfo: Pointer to configuration structure. 
+ * @param pClocks: pointer used to store results.         
+ * @return return none.
+*/
+void AD5940_ClksCalculate(ClksCalInfo_Type *pFilterInfo, uint32_t *pClocks)
+{
+  uint32_t temp = 0;
+  const uint32_t sinc2osr_table[] = {22,44,89,178,267,533,640,667,800,889,1067,1333,0};
+  const uint32_t sinc3osr_table[] = {5,4,2,0};
+
+  *pClocks = 0;
+  if(pFilterInfo == NULL) return;
+  if(pClocks == NULL) return;
+  if(pFilterInfo->ADCSinc2Osr > ADCSINC2OSR_1333) return;
+  if(pFilterInfo->ADCSinc3Osr > 2)  return; /* 0: OSR5, 1:OSR4, 2:OSR2 */
+  if(pFilterInfo->ADCAvgNum > ADCAVGNUM_16) return; /* Average number index:0,1,2,3 */
+  switch(pFilterInfo->DataType)
+  {
+    case DATATYPE_ADCRAW:
+      temp = (uint32_t)(20*pFilterInfo->DataCount*pFilterInfo->RatioSys2AdcClk);
+      break;
+    case DATATYPE_SINC3:
+      temp = (uint32_t)(((pFilterInfo->DataCount+2)*sinc3osr_table[pFilterInfo->ADCSinc3Osr]+1)*20*pFilterInfo->RatioSys2AdcClk + 0.5f);
+      break;
+    case DATATYPE_SINC2: 
+      temp = (pFilterInfo->DataCount+1)*sinc2osr_table[pFilterInfo->ADCSinc2Osr] + 1;
+      pFilterInfo->DataType = DATATYPE_SINC3;
+      pFilterInfo->DataCount = temp;
+      AD5940_ClksCalculate(pFilterInfo, &temp);
+      pFilterInfo->DataType = DATATYPE_SINC2;
+      temp += 15;   /* Need extra 15 clocks for FIFO etc. Just to be safe. */
+      break;
+    case DATATYPE_NOTCH:
+    {
+      ADCFilterCfg_Type filter;
+      filter.ADCRate = pFilterInfo->ADCRate;
+      filter.ADCSinc3Osr = pFilterInfo->ADCSinc3Osr;
+      filter.ADCSinc2Osr = pFilterInfo->ADCSinc2Osr;
+      uint8_t dl=0, dl_50, dl_60;
+      if(AD5940_Notch50HzAvailable(&filter, &dl_50)){
+        dl += dl_50 - 1;
+      }
+      if(AD5940_Notch60HzAvailable(&filter, &dl_60)){
+        dl += dl_60 - 1;
+      }
+      pFilterInfo->DataType = DATATYPE_SINC2;
+      pFilterInfo->DataCount += dl; //DL is the extra data input needed for filter to output first data.
+      AD5940_ClksCalculate(pFilterInfo,&temp);
+      //restore the filter info.
+      pFilterInfo->DataType = DATATYPE_NOTCH;
+      pFilterInfo->DataCount -= dl;
+      break;
+    }
+    case DATATYPE_DFT:
+      switch(pFilterInfo->DftSrc)
+      {
+        case DFTSRC_ADCRAW:
+          pFilterInfo->DataType = DATATYPE_ADCRAW;
+          AD5940_ClksCalculate(pFilterInfo, &temp);
+          break;
+        case DFTSRC_SINC3:
+          pFilterInfo->DataType = DATATYPE_SINC3;
+          AD5940_ClksCalculate(pFilterInfo, &temp);
+          break;
+        case DFTSRC_SINC2NOTCH:
+          if(pFilterInfo->BpNotch)
+            pFilterInfo->DataType = DATATYPE_SINC2;
+          else
+            pFilterInfo->DataType = DATATYPE_NOTCH;
+          AD5940_ClksCalculate(pFilterInfo, &temp);
+          break;
+        case DFTSRC_AVG:
+          pFilterInfo->DataType = DATATYPE_SINC3;
+          pFilterInfo->DataCount *= 1L<<(pFilterInfo->ADCAvgNum+1); /* 0: average2, 1: average4, 2: average8, 3: average16 */
+          AD5940_ClksCalculate(pFilterInfo, &temp);
+          break;
+        default:
+          break;
+      }
+      pFilterInfo->DataType = DATATYPE_DFT;
+      temp += 25; /* add margin */
+      break;
+    default:
+    break;
+  }
+  *pClocks = temp;
+}
+
+/**
+   @brief void AD5940_SweepNext(SoftSweepCfg_Type *pSweepCfg, float *pNextFreq)
+          For sweep function, calculate next frequency point according to pSweepCfg info.
+   @return Return next frequency point in Hz.
+*/
+void AD5940_SweepNext(SoftSweepCfg_Type *pSweepCfg, float *pNextFreq)
+{
+   float frequency;
+
+   if(pSweepCfg->SweepLog)/* Log step */
+   {
+      if(pSweepCfg->SweepStart<pSweepCfg->SweepStop) /* Normal */
+      {
+         if(++pSweepCfg->SweepIndex == pSweepCfg->SweepPoints)
+            pSweepCfg->SweepIndex = 0;
+         frequency = pSweepCfg->SweepStart*pow(10,pSweepCfg->SweepIndex*log10(pSweepCfg->SweepStop/pSweepCfg->SweepStart)/(pSweepCfg->SweepPoints-1));
+      }
+      else
+      {
+         pSweepCfg->SweepIndex --;
+         if(pSweepCfg->SweepIndex >= pSweepCfg->SweepPoints)
+            pSweepCfg->SweepIndex = pSweepCfg->SweepPoints-1;
+         frequency = pSweepCfg->SweepStop*pow(10,pSweepCfg->SweepIndex*
+                                     (log10(pSweepCfg->SweepStart/pSweepCfg->SweepStop)/(pSweepCfg->SweepPoints-1)));
+      }
+   }
+   else/* Linear step */
+   {
+      if(pSweepCfg->SweepStart<pSweepCfg->SweepStop) /* Normal */
+      {
+         if(++pSweepCfg->SweepIndex == pSweepCfg->SweepPoints)
+            pSweepCfg->SweepIndex = 0;
+         frequency = pSweepCfg->SweepStart + pSweepCfg->SweepIndex*(double)(pSweepCfg->SweepStop-pSweepCfg->SweepStart)/(pSweepCfg->SweepPoints-1);
+      }
+      else
+      {
+         pSweepCfg->SweepIndex --;
+         if(pSweepCfg->SweepIndex >= pSweepCfg->SweepPoints)
+            pSweepCfg->SweepIndex = pSweepCfg->SweepPoints-1;
+         frequency = pSweepCfg->SweepStop + pSweepCfg->SweepIndex*(double)(pSweepCfg->SweepStart - pSweepCfg->SweepStop)/(pSweepCfg->SweepPoints-1);
+      }
+   }
+   
+   *pNextFreq = frequency;
+}
+
+/**
+  @brief Initialize Structure members to zero
+  @param pStruct: Pointer to the structure. 
+  @param StructSize: The structure size in Byte.
+  @return Return None.
+**/
+void AD5940_StructInit(void *pStruct, uint32_t StructSize)
+{
+  memset(pStruct, 0, StructSize);
+}
+
+/**
+  @brief Convert ADC Code to voltage. 
+  @param ADCPga: The ADC PGA used for this result.
+  @param code: ADC code.
+  @param VRef1p82: the actual 1.82V reference voltage.
+  @return Voltage in volt.
+**/
+float AD5940_ADCCode2Volt(uint32_t code, uint32_t ADCPga, float VRef1p82)
+{
+  float kFactor = 1.835/1.82;
+  float fVolt = 0.0;
+  float tmp = 0;
+  tmp = (int32_t)code - 32768;
+  switch(ADCPga)
+  {
+  case ADCPGA_1:
+    break;
+  case ADCPGA_1P5:
+    tmp /= 1.5f;
+    break;
+  case ADCPGA_2:
+    tmp /= 2.0f;
+    break;
+  case ADCPGA_4:
+    tmp /= 4.0f;
+    break;
+  case ADCPGA_9:
+    tmp /= 9.0f;
+    break;
+  default:break;
+  }
+  fVolt = tmp*VRef1p82/32768*kFactor;
+  return fVolt;
+}
+
+/**
+ * @brief Do complex number division.
+ * @param a: The dividend.
+ * @param b: The divisor.
+ * @return Return result.
+**/
+fImpCar_Type AD5940_ComplexDivFloat(fImpCar_Type *a, fImpCar_Type *b)
+{
+  fImpCar_Type res;
+  float temp;
+  temp = b->Real*b->Real + b->Image*b->Image;
+  res.Real = a->Real*b->Real + a->Image*b->Image;
+  res.Real /= temp;
+  res.Image = a->Image*b->Real - a->Real*b->Image;
+  res.Image /= temp;
+  return res;
+}
+
+/**
+ * @brief Do complex number multiplication.
+ * @param a: The multiplicand.
+ * @param b: The multiplier .
+ * @return Return result.
+**/
+fImpCar_Type AD5940_ComplexMulFloat(fImpCar_Type *a, fImpCar_Type *b)
+{
+  fImpCar_Type res;
+  
+  res.Real = a->Real*b->Real - a->Image*b->Image;
+  res.Image = a->Image*b->Real + a->Real*b->Image;
+
+  return res;
+}
+/**
+ * @brief Do complex number addition.
+ * @param a: The addend.
+ * @param b: The addend .
+ * @return Return result.
+**/
+fImpCar_Type AD5940_ComplexAddFloat(fImpCar_Type *a, fImpCar_Type *b)
+{
+  fImpCar_Type res;
+  
+  res.Real = a->Real + b->Real;
+  res.Image = a->Image + b->Image;
+
+  return res;
+}
+
+/**
+ * @brief Do complex number subtraction.
+ * @param a: The minuend.
+ * @param b: The subtrahend .
+ * @return Return result.
+**/
+fImpCar_Type AD5940_ComplexSubFloat(fImpCar_Type *a, fImpCar_Type *b)
+{
+  fImpCar_Type res;
+  
+  res.Real = a->Real - b->Real;
+  res.Image = a->Image - b->Image;
+
+  return res;
+}
+
+/**
+ * @brief Do complex number division.
+ * @param a: The dividend.
+ * @param b: The divisor.
+ * @return Return result.
+**/
+fImpCar_Type AD5940_ComplexDivInt(iImpCar_Type *a, iImpCar_Type *b)
+{
+  fImpCar_Type res;
+  float temp;
+  temp = (float)b->Real*b->Real + (float)b->Image*b->Image;
+  res.Real = (float)a->Real*b->Real + (float)a->Image*b->Image;
+  res.Real /= temp;
+  res.Image = (float)a->Image*b->Real - (float)a->Real*b->Image;
+  res.Image /= temp;
+  return res;
+}
+
+/**
+ * @brief Do complex number multiplication.
+ * @param a: The multiplicand.
+ * @param b: The multiplier .
+ * @return Return result.
+**/
+fImpCar_Type AD5940_ComplexMulInt(iImpCar_Type *a, iImpCar_Type *b)
+{
+  fImpCar_Type res;
+  
+  res.Real = (float)a->Real*b->Real - (float)a->Image*b->Image;
+  res.Image = (float)a->Image*b->Real + (float)a->Real*b->Image;
+
+  return res;
+}
+
+/**
+ * @brief Calculate the complex number magnitude.
+ * @param a: The complex number.
+ * @return Return magnitude.
+**/
+float AD5940_ComplexMag(fImpCar_Type *a)
+{
+  return sqrt(a->Real*a->Real + a->Image*a->Image);
+}
+
+/**
+ * @brief Calculate the complex number phase.
+ * @param a: The complex number.
+ * @return Return phase.
+**/
+float AD5940_ComplexPhase(fImpCar_Type *a)
+{
+  return atan2(a->Image, a->Real);
+}
+
+/**
+ * @brief Calculate the optimum filter settings based on signal frequency.
+ * @param freq: Frequency of signalr.
+ * @return Return FreqParams.
+**/
+FreqParams_Type AD5940_GetFreqParameters(float freq)
+{
+	const uint32_t dft_table[] = {4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
+	const uint32_t sinc2osr_table[] = {1, 22,44,89,178,267,533,640,667,800,889,1067,1333};
+  const uint32_t sinc3osr_table[] = {2, 4, 5};
+	float AdcRate = 800000;
+	uint32_t n1 = 0;	// Sample rate after ADC filters
+	uint32_t n2 = 0; // Sample rate after DFT block
+	uint32_t iCycle = 0;
+	FreqParams_Type freq_params;
+	/* High power mode */
+	if(freq >= 20000)
+	{
+		freq_params. DftSrc = DFTSRC_SINC3;
+		freq_params.ADCSinc2Osr = 0;
+		freq_params.ADCSinc3Osr = 2;
+		freq_params.DftNum = DFTNUM_8192;
+		freq_params.NumClks = 0;
+		freq_params.HighPwrMode = bTRUE;
+		return freq_params;		
+	}
+	
+	if(freq < 0.51)
+	{
+		freq_params. DftSrc = DFTSRC_SINC2NOTCH;
+		freq_params.ADCSinc2Osr = 6;
+		freq_params.ADCSinc3Osr = 1;
+		freq_params.DftNum = DFTNUM_8192;
+		freq_params.NumClks = 0;
+		freq_params.HighPwrMode = bTRUE;
+		return freq_params;		
+	}
+	
+	/* Start with SINC2 setting */
+	for(uint8_t i = 0; i<sizeof(sinc2osr_table) / sizeof(uint32_t); i++)
+	{
+		n1 = sinc2osr_table[i] * sinc3osr_table[1];
+		if(((AdcRate/n1) < freq * 10) && (freq<20e3))
+			continue;
+		
+		/* Try DFT number */
+		for(uint32_t j = 8; j<sizeof(dft_table) / sizeof(uint32_t); j++)
+		{
+			n2 = dft_table[j];
+			iCycle = (uint32_t)(n1 * n2 * freq)/AdcRate;
+			if(iCycle < 8)
+				continue;
+			freq_params. DftSrc = DFTSRC_SINC2NOTCH;
+			freq_params.ADCSinc2Osr = i-1;
+			freq_params.ADCSinc3Osr = 1;
+			freq_params.DftNum = j;
+			freq_params.NumClks = 0;
+			freq_params.HighPwrMode = bFALSE;
+			if(n1 == 4)
+			{
+				freq_params. DftSrc = DFTSRC_SINC3;
+				freq_params.ADCSinc2Osr = 0;
+			}
+			return freq_params;
+		}
+	}
+		
+	return freq_params;
+}
+
+/**
+ * @} Function_Helpers
+*/
+
+#ifdef CHIPSEL_M355
+static void AD5940_D2DWriteReg(uint16_t RegAddr, uint32_t RegData)
+{
+  if(((RegAddr>=0x1000)&&(RegAddr<=0x3014)))  /* 32bit register */
+    *(volatile uint32_t *)(RegAddr+0x400c0000) = RegData;
+  else                                        /* 16bit register */
+    *(volatile uint16_t *)(RegAddr+0x400c0000) = RegData;
+}
+
+static uint32_t AD5940_D2DReadReg(uint16_t RegAddr)
+{
+  if(((RegAddr>=0x1000)&&(RegAddr<=0x3014)))  /* 32bit register */
+    return *(volatile uint32_t *)(RegAddr+0x400c0000);
+  else                                        /* 16bit register */
+    return *(volatile uint16_t *)(RegAddr+0x400c0000);
+}
+
+void AD5940_FIFORd(uint32_t *pBuffer, uint32_t uiReadCount)   
+{
+  while(uiReadCount--)
+    *pBuffer++ = *(volatile uint32_t *)(0x400c206C);
+}
+#else
+/**
+ * @defgroup SPI_Block
+ * @brief Functions to communicate with AD5940 registers following AD5940 SPI protocols
+ * @{
+ * 
+ * @defgroup SPI_Block_Functions
+ * @brief The basic SPI protocols. All functions are basic on AD5940_ReadWriteNBytes which
+ *        provided by user.
+ *        
+ *  ##SPI basic protocol
+ *        All SPI protocol starts with one-byte command word. Following are data(16B or 32B)
+ *        There are four SPI commands available @ref SPI_Block_Const.
+ * @{
+*/
+
+/**
+  @brief Using SPI to transmit one byte and return the received byte. 
+  @param data: The 8-bit data SPI will transmit.
+  @return received data.
+**/
+static unsigned char AD5940_ReadWrite8B(unsigned char data)
+{
+   uint8_t tx[1], rx[1];
+   tx[0] = data;
+   AD5940_ReadWriteNBytes(tx,rx,1);
+   return rx[0];
+}
+
+/**
+  @brief Using SPI to transmit two bytes and return the received bytes. 
+  @param data: The 16-bit data SPI will transmit.
+  @return received data.
+**/
+static uint16_t AD5940_ReadWrite16B(uint16_t data)
+{
+   uint8_t SendBuffer[2];
+   uint8_t RecvBuffer[2];
+   SendBuffer[0] = data>>8;
+   SendBuffer[1] = data&0xff;
+   AD5940_ReadWriteNBytes(SendBuffer,RecvBuffer,2);
+   return (((uint16_t)RecvBuffer[0])<<8)|RecvBuffer[1];
+}
+
+/**
+ * @brief Using SPI to transmit four bytes and return the received bytes. 
+ * @param data: The 32-bit data SPI will transmit.
+ * @return received data.
+**/
+static uint32_t AD5940_ReadWrite32B(uint32_t data)
+{
+   uint8_t SendBuffer[4];
+   uint8_t RecvBuffer[4];
+  
+   SendBuffer[0] = (data>>24)&0xff;
+   SendBuffer[1] = (data>>16)&0xff;
+   SendBuffer[2] = (data>> 8)&0xff;
+   SendBuffer[3] = (data    )&0xff;
+   AD5940_ReadWriteNBytes(SendBuffer,RecvBuffer,4);
+   return (((uint32_t)RecvBuffer[0])<<24)|(((uint32_t)RecvBuffer[1])<<16)|(((uint32_t)RecvBuffer[2])<<8)|RecvBuffer[3];
+}
+
+/**
+ * @brief Write register through SPI.
+ * @param RegAddr: The register address.
+ * @param RegData: The register data.
+ * @return Return None.
+**/
+static void AD5940_SPIWriteReg(uint16_t RegAddr, uint32_t RegData)
+{  
+  /* Set register address */
+  AD5940_CsClr();
+  AD5940_ReadWrite8B(SPICMD_SETADDR);
+  AD5940_ReadWrite16B(RegAddr);
+  AD5940_CsSet();
+  /* Add delay here to meet the SPI timing. */
+  AD5940_CsClr();
+  AD5940_ReadWrite8B(SPICMD_WRITEREG);
+  if(((RegAddr>=0x1000)&&(RegAddr<=0x3014)))
+    AD5940_ReadWrite32B(RegData);
+  else
+    AD5940_ReadWrite16B(RegData);
+  AD5940_CsSet();
+}
+
+/**
+ * @brief Read register through SPI.
+ * @param RegAddr: The register address.
+ * @return Return register data.
+**/
+static uint32_t AD5940_SPIReadReg(uint16_t RegAddr)
+{  
+  uint32_t Data = 0;
+  /* Set register address that we want to read */
+  AD5940_CsClr();
+  AD5940_ReadWrite8B(SPICMD_SETADDR);
+  AD5940_ReadWrite16B(RegAddr);
+  AD5940_CsSet();
+  /* Read it */
+  AD5940_CsClr();
+  AD5940_ReadWrite8B(SPICMD_READREG);
+  AD5940_ReadWrite8B(0);  //Dummy read
+  /* The real data is coming */
+  if((RegAddr>=0x1000)&&(RegAddr<=0x3014))
+    Data = AD5940_ReadWrite32B(0);
+  else
+    Data = AD5940_ReadWrite16B(0);
+  AD5940_CsSet();
+  return Data;
+}
+
+/**
+  @brief Read specific number of data from FIFO with optimized SPI access.
+  @param pBuffer: Pointer to a buffer that used to store data read back.
+  @param uiReadCount: How much data to be read.
+  @return none.
+**/
+void AD5940_FIFORd(uint32_t *pBuffer, uint32_t uiReadCount)   
+{
+  /* Use function AD5940_SPIReadReg to read REG_AFE_DATAFIFORD is also one method. */
+   uint32_t i;
+   
+   if(uiReadCount < 3)
+   {
+      /* This method is more efficient when readcount < 3 */
+      uint32_t i;
+      AD5940_CsClr();
+      AD5940_ReadWrite8B(SPICMD_SETADDR);
+      AD5940_ReadWrite16B(REG_AFE_DATAFIFORD);
+      AD5940_CsSet();
+      for(i=0;i<uiReadCount;i++)
+      {
+         AD5940_CsClr();
+         AD5940_ReadWrite8B(SPICMD_READREG);
+         AD5940_ReadWrite8B(0);//Write Host status/Don't care
+         pBuffer[i] = AD5940_ReadWrite32B(0);
+         AD5940_CsSet();
+      }
+   }
+   else
+   {
+      AD5940_CsClr();
+      AD5940_ReadWrite8B(SPICMD_READFIFO);
+      /* 6 dummy write before valid data read back */
+      for(i=0;i<6;i++)
+         AD5940_ReadWrite8B(0);
+      /* Continuously read DATAFIFORD register with offset 0 */
+      for(i=0;i<uiReadCount-2;i++)
+      {
+         pBuffer[i] = AD5940_ReadWrite32B(0); /*Offset is 0, so we always read DATAFIFORD register */
+      }
+      /* Read back last two FIFO data with none-zero offset*/
+      pBuffer[i++] = AD5940_ReadWrite32B(0x44444444);
+      pBuffer[i] = AD5940_ReadWrite32B(0x44444444);
+      AD5940_CsSet();
+   }
+}
+
+/**
+ * @} SPI_Block_Functions
+ * @} SPI_Block
+*/
+#endif
+
+/**
+ * @brief Write register. If sequencer generator is enabled, the register write is recorded. 
+ *        Otherwise, the data is written to AD5940 by SPI.
+ * @param RegAddr: The register address.
+ * @param RegData: The register data.
+ * @return Return None.
+**/
+void AD5940_WriteReg(uint16_t RegAddr, uint32_t RegData)
+{
+#ifdef SEQUENCE_GENERATOR
+  if(SeqGenDB.EngineStart == bTRUE)
+    AD5940_SEQWriteReg(RegAddr, RegData);
+  else
+#endif
+#ifdef CHIPSEL_M355
+    AD5940_D2DWriteReg(RegAddr, RegData);
+#else
+    AD5940_SPIWriteReg(RegAddr, RegData);
+#endif
+}
+
+/**
+ * @brief Read register. If sequencer generator is enabled, read current register value from data-base. 
+ *        Otherwise, read register value by SPI.
+ * @param RegAddr: The register address.
+ * @return Return register value.
+**/
+uint32_t AD5940_ReadReg(uint16_t RegAddr)
+{
+#ifdef SEQUENCE_GENERATOR
+  if(SeqGenDB.EngineStart == bTRUE)
+    return AD5940_SEQReadReg(RegAddr);
+  else
+#endif
+#ifdef CHIPSEL_M355
+    return AD5940_D2DReadReg(RegAddr);
+#else
+    return AD5940_SPIReadReg(RegAddr);
+#endif
+}
+
+
+/**
+ * @defgroup AFE_Control 
+ * @brief Some functions to control the whole AFE. They are top level switches.
+ * @{
+ *    @defgroup AFE_Control_Functions
+ *    The top-level control functions for whole AFE perspective. 
+ *    @details  This function set is used to control the whole AFE block by block. It's a top-level configuration.
+ *              It's convenient when do initialization work with the functions called BLOCK**Cfg**. You can tune the parameters at run-time using more detailed
+ *              functions from each block. rather than top-level functions where you need to configure all parameters.
+ *    @{
+*/
+
+/**
+ * @brief Initialize AD5940. This function must be called whenever there is reset(Software Reset or Hardware reset or Power up) happened.
+ *        This function is used to put AD5940 to correct state.
+ * @return return None
+**/
+void AD5940_Initialize(void)
+{
+  int i;
+  /* Write following registers with its data sequentially whenever there is a reset happened. */
+  const struct
+  {
+    uint16_t reg_addr;
+    uint32_t reg_data;
+  }RegTable[]=
+  {
+    {0x0908, 0x02c9},
+    {0x0c08, 0x206C},
+    {0x21F0, 0x0010},
+#ifndef CHIPSEL_M355
+    /* This is AD5940 */
+    {0x0410, 0x02c9},
+    {0x0A28, 0x0009},
+#else
+    /* This is ADuCM355 */
+    {0x0410, 0x001a},
+    {0x0A28, 0x0008},
+#endif
+    {0x238c, 0x0104},
+    {0x0a04, 0x4859},
+    {0x0a04, 0xF27B},
+    {0x0a00, 0x8009},
+    {0x22F0, 0x0000},
+    //
+    {0x2230, 0xDE87A5AF},
+    {0x2250, 0x103F},
+    {0x22B0, 0x203C},
+    {0x2230, 0xDE87A5A0},
+  };
+  //initialize global variables
+  SeqGenDB.SeqLen = 0;
+  SeqGenDB.RegCount = 0;
+  SeqGenDB.LastError = AD5940ERR_OK;
+  SeqGenDB.EngineStart = bFALSE;
+#ifndef CHIPSEL_M355
+  AD5940_CsSet(); /* Pull high CS in case it's low */
+#endif
+  for(i=0; i<sizeof(RegTable)/sizeof(RegTable[0]); i++)
+    AD5940_WriteReg(RegTable[i].reg_addr, RegTable[i].reg_data);
+  i = AD5940_ReadReg(REG_AFECON_CHIPID);  
+  if(i == 0x5501)
+    bIsS2silicon = bTRUE;
+  else if(i == 0x5502)  /* S3 chip-id is 0x5502. The is no difference with S2. */
+    bIsS2silicon = bTRUE;
+  else if(i == 0x5500)
+    bIsS2silicon = bFALSE;
+#ifdef ADI_DEBUG
+  else
+  {
+    printf("CHIPID read error:0x%04x. AD5940 is not present?\n", i);
+    while(1);
+  }
+#ifdef CHIPSEL_M355
+  ADI_Print("This ADuCM355!\n");
+#else
+  ADI_Print("This AD594x!\n");
+#endif
+  ADI_Print("Note: Current Silicon is %s\n", bIsS2silicon?"S2":"S1");
+  ADI_Print("AD5940LIB Version:v%d.%d.%d\n", AD5940LIB_VER_MAJOR, AD5940LIB_VER_MINOR, AD5940LIB_VER_PATCH);
+#endif
+}
+
+/**
+ * @brief Control most AFE digital and analog block within one register access.
+ * @param AfeCtrlSet: A set of blocks that will be controlled select it from @ref AFECTRL_Const Below is two examples to use it.
+ *        - AFECTRL_HPREFPWR: Control high power reference(bandgap).
+ *        - AFECTRL_WG|AFECTRL_ADCPWR: The OR'ed control set. Control Waveform generator and ADC power.
+ * @param State: Enable or disable selected control set signal. Select from @BoolFlag
+ *        - bFALSE: Disable or power down selected block(s).
+ *        - bTRUE:  Enable all selected block(s).
+   @return return none.
+*/
+void AD5940_AFECtrlS(uint32_t AfeCtrlSet, BoolFlag State)
+{
+  /* Check parameters */
+  uint32_t tempreg;
+  tempreg = AD5940_ReadReg(REG_AFE_AFECON);
+  if (State == bTRUE) {
+    /* Clear bits to enable HPREF and ALDOLimit*/
+    if (AfeCtrlSet & AFECTRL_HPREFPWR) {
+        tempreg &= ~BITM_AFE_AFECON_HPREFDIS;
+        AfeCtrlSet &= ~AFECTRL_HPREFPWR;
+    }
+    if(AfeCtrlSet & AFECTRL_ALDOLIMIT)
+    {
+      tempreg &= ~BITM_AFE_AFECON_ALDOILIMITEN;
+      AfeCtrlSet &= ~AFECTRL_ALDOLIMIT;
+    }
+    tempreg |= AfeCtrlSet;
+  }
+  else
+  {
+    /* Set bits to Disable HPREF and ALDOLimit*/
+    if(AfeCtrlSet & AFECTRL_HPREFPWR)
+    {
+        tempreg |= BITM_AFE_AFECON_HPREFDIS;
+        AfeCtrlSet &= ~AFECTRL_HPREFPWR;
+    }
+    if(AfeCtrlSet & AFECTRL_ALDOLIMIT)
+    {
+      tempreg |= BITM_AFE_AFECON_ALDOILIMITEN;
+      AfeCtrlSet &= ~AFECTRL_ALDOLIMIT;
+    }
+    tempreg &= ~AfeCtrlSet;
+  }
+  AD5940_WriteReg(REG_AFE_AFECON, tempreg);
+}
+/** When LP mode is enabled, some functions are under control of LPMODECON, rather than original registers.  */
+/** @warning LPMODE is key protected, this function only takes effect after AD5940_LPModeEnS(bTRUE) */
+/**
+ * @brief For LP mode, use one register to control most AFE digital and analog block.
+ * @details The parameter means the blocks. The selected block will be enabled. All others will be disabled.
+ *          The method to enable/disable blocks are defined by register LPMODECON, either by clearing or setting bits.
+ * @param EnSet: A set of blocks that will be enabled. Select it from @ref LPMODECTRL_Const. All others not selected in EnSet will be disabled.
+ *        - LPMODECTRL_ALDOPWR|LPMODECTRL_HFOSCEN: Turn on ALDO and HFOSC, disable all others.
+ *        - LPMODECTRL_ALL: Enable all blocks.
+   @return return none.
+*/
+AD5940Err AD5940_LPModeCtrlS(uint32_t EnSet)
+{
+  /* Check parameters */
+  uint32_t tempreg;
+  uint32_t DisSet;    /* The blocks to be disabled */
+  DisSet = LPMODECTRL_ALL & (~EnSet);
+  tempreg = AD5940_ReadReg(REG_AFE_LPMODECON);
+  /* Enable selected set */
+  {
+    /* Clear bits to enable HFOSC, HPREF, ALDO */
+    if (EnSet & LPMODECTRL_HFOSCEN) {
+        tempreg &= ~BITM_AFE_LPMODECON_HFOSCPD;
+        EnSet &= ~LPMODECTRL_HFOSCEN;
+    }
+    if(EnSet & LPMODECTRL_HPREFPWR)
+    {
+      tempreg &= ~BITM_AFE_LPMODECON_HPREFDIS;
+      EnSet &= ~LPMODECTRL_HPREFPWR;
+    }
+    if(EnSet & LPMODECTRL_ALDOPWR)
+    {
+      tempreg &= ~BITM_AFE_LPMODECON_ALDOEN;
+      EnSet &= ~LPMODECTRL_ALDOPWR;
+    }
+    tempreg |= EnSet; /* Set other bits to enable function */
+  }
+  /* Disable other blocks */
+  {
+    /* Set bits to disable HFOSC, HPREF, ALDO */
+    if (DisSet & LPMODECTRL_HFOSCEN) {
+        tempreg |= BITM_AFE_LPMODECON_HFOSCPD;
+        DisSet &= ~LPMODECTRL_HFOSCEN;
+    }
+    if(DisSet & LPMODECTRL_HPREFPWR)
+    {
+      tempreg |= BITM_AFE_LPMODECON_HPREFDIS;
+      DisSet &= ~LPMODECTRL_HPREFPWR;
+    }
+    if(DisSet & LPMODECTRL_ALDOPWR)
+    {
+      tempreg |= BITM_AFE_LPMODECON_ALDOEN;
+      DisSet &= ~LPMODECTRL_ALDOPWR;
+    }
+    tempreg &= ~DisSet; /* Clear other bits to disable function */
+  }
+  AD5940_WriteReg(REG_AFE_LPMODECON, tempreg);
+
+  return AD5940ERR_OK;
+}
+
+/**
+   @brief Set AFE power mode and system bandwidth include HSDAC, Excitation-buffer, HSTIA and ADC etc.
+   @param AfePwr : {AFEPWR_LP, AFEPWR_HP}
+          Select parameters from @ref AFEPWR_Const
+          - AFEPWR_LP: Set AFE to low power mode
+          - AFEPWR_HP: Set AFE to High speed mode to support 200kHz.
+   @param AfeBw : {AFEBW_AUTOSET, AFEBW_50KHZ, AFEBW_100KHZ, AFEBW_250KHZ}
+          - AFEBW_AUTOSET: Set the bandwidth automatically based on WGFCW frequency word.
+          - AFEBW_50KHZ: Set system bandwidth to 50kHz.
+          - AFEBW_100KHZ: Set system bandwidth to 100kHz.
+          - AFEBW_250KHZ: Set system bandwidth to 250kHz.
+   @return return none.
+*/
+void AD5940_AFEPwrBW(uint32_t AfePwr, uint32_t AfeBw)
+{
+  //check parameters
+  uint32_t tempreg;
+  tempreg = AfePwr;
+  tempreg |= AfeBw << BITP_AFE_PMBW_SYSBW;
+  AD5940_WriteReg(REG_AFE_PMBW, tempreg);
+}
+
+/**
+   @brief Configure reference buffer include 1.8V/1.1V high/low power buffers.
+   @param pBufCfg :Pointer to buffer configure structure;
+   @return return none.
+*/
+void AD5940_REFCfgS(AFERefCfg_Type *pBufCfg)
+{
+  uint32_t tempreg;
+  
+  /* HP Reference(bandgap) */
+  tempreg = AD5940_ReadReg(REG_AFE_AFECON);
+  tempreg &= ~BITM_AFE_AFECON_HPREFDIS;
+  if(pBufCfg->HpBandgapEn == bFALSE)
+    tempreg |= BITM_AFE_AFECON_HPREFDIS;
+  AD5940_WriteReg(REG_AFE_AFECON, tempreg);
+  /* Reference buffer configure */
+  tempreg = AD5940_ReadReg(REG_AFE_BUFSENCON);
+  if(pBufCfg->Hp1V8BuffEn == bTRUE)
+    tempreg |= BITM_AFE_BUFSENCON_V1P8HPADCEN;
+  if(pBufCfg->Hp1V1BuffEn == bTRUE)
+    tempreg |= BITM_AFE_BUFSENCON_V1P1HPADCEN;
+  if(pBufCfg->Lp1V8BuffEn == bTRUE)
+    tempreg |= BITM_AFE_BUFSENCON_V1P8LPADCEN;
+  if(pBufCfg->Lp1V1BuffEn == bTRUE)
+    tempreg |= BITM_AFE_BUFSENCON_V1P1LPADCEN;
+  if(pBufCfg->Hp1V8ThemBuff == bTRUE)
+    tempreg |= BITM_AFE_BUFSENCON_V1P8THERMSTEN;
+  if(pBufCfg->Hp1V8Ilimit == bTRUE)
+    tempreg |= BITM_AFE_BUFSENCON_V1P8HPADCILIMITEN;
+  if(pBufCfg->Disc1V8Cap == bTRUE)
+    tempreg |= BITM_AFE_BUFSENCON_V1P8HPADCCHGDIS;
+  if(pBufCfg->Disc1V1Cap == bTRUE)
+    tempreg |= BITM_AFE_BUFSENCON_V1P1LPADCCHGDIS;
+  AD5940_WriteReg(REG_AFE_BUFSENCON, tempreg);
+
+  /* LPREFBUFCON */
+  tempreg = 0;
+  if(pBufCfg->LpRefBufEn == bFALSE)
+    tempreg |= BITM_AFE_LPREFBUFCON_LPBUF2P5DIS;
+  if(pBufCfg->LpBandgapEn == bFALSE)
+    tempreg |= BITM_AFE_LPREFBUFCON_LPREFDIS;
+  if(pBufCfg->LpRefBoostEn == bTRUE)
+    tempreg |= BITM_AFE_LPREFBUFCON_BOOSTCURRENT;
+  AD5940_WriteReg(REG_AFE_LPREFBUFCON, tempreg);
+}
+/**
+ * @} End of AFE_Control_Functions
+ * @} End of AFE_Control
+ * */
+
+/**
+ * @defgroup High_Speed_Loop
+ * @brief The high speed loop
+ * @{
+ *    @defgroup High_Speed_Loop_Functions
+ *    @{
+*/
+
+/**
+   @brief Configure High speed loop(high bandwidth loop or 
+          called excitation loop). This configuration includes HSDAC, HSTIA and Switch matrix. 
+   @param pHsLoopCfg : Pointer to configure structure;
+   @return return none.
+*/
+void AD5940_HSLoopCfgS(HSLoopCfg_Type *pHsLoopCfg)
+{
+  AD5940_HSDacCfgS(&pHsLoopCfg->HsDacCfg);
+  AD5940_HSTIACfgS(&pHsLoopCfg->HsTiaCfg);
+  AD5940_SWMatrixCfgS(&pHsLoopCfg->SWMatCfg);
+  AD5940_WGCfgS(&pHsLoopCfg->WgCfg);
+}
+
+/**
+   @brief Initialize switch matrix
+   @param pSwMatrix: Pointer to configuration structure
+   @return return none.
+*/
+void AD5940_SWMatrixCfgS(SWMatrixCfg_Type *pSwMatrix)
+{
+  AD5940_WriteReg(REG_AFE_DSWFULLCON, pSwMatrix->Dswitch);
+  AD5940_WriteReg(REG_AFE_PSWFULLCON, pSwMatrix->Pswitch);
+  AD5940_WriteReg(REG_AFE_NSWFULLCON, pSwMatrix->Nswitch);
+  AD5940_WriteReg(REG_AFE_TSWFULLCON, pSwMatrix->Tswitch);
+  AD5940_WriteReg(REG_AFE_SWCON, BITM_AFE_SWCON_SWSOURCESEL); /* Update switch configuration */
+}
+
+/**
+   @brief Initialize HSDAC
+   @param pHsDacCfg: Pointer to configuration structure
+   @return return none.
+*/
+void AD5940_HSDacCfgS(HSDACCfg_Type *pHsDacCfg)
+{
+  uint32_t tempreg;
+  //Check parameters
+  tempreg = 0;
+  if(pHsDacCfg->ExcitBufGain == EXCITBUFGAIN_0P25)
+    tempreg |= BITM_AFE_HSDACCON_INAMPGNMDE; /* Enable attenuator */
+  if(pHsDacCfg->HsDacGain == HSDACGAIN_0P2)
+    tempreg |= BITM_AFE_HSDACCON_ATTENEN; /* Enable attenuator */
+  tempreg |= (pHsDacCfg->HsDacUpdateRate&0xff)<<BITP_AFE_HSDACCON_RATE;
+  AD5940_WriteReg(REG_AFE_HSDACCON, tempreg);
+}
+
+
+static void __AD5940_SetDExRTIA(uint32_t DExPin, uint32_t DeRtia, uint32_t DeRload)
+{
+  uint32_t tempreg;
+  /* deal with HSTIA DE RTIA */
+  if(DeRtia >= HSTIADERTIA_OPEN)
+    tempreg = 0x1f << 3;  /* bit field HPTIRES03CON[7:3] */
+  else if(DeRtia >= HSTIADERTIA_1K)
+  {
+    tempreg = (DeRtia - 3 + 11) << 3;
+  }
+  else  /* DERTIA 50/100/200Ohm */
+  {
+    const uint8_t DeRtiaTable[3][5] = 
+    {
+//Rload  0      10    30    50    100 
+			{0x00, 0x01, 0x02, 0x03, 0x06}, /* RTIA 50Ohm */
+			{0x03, 0x04, 0x05, 0x06, 0x07}, /* RTIA 100Ohm */
+			{0x07, 0x07, 0x09, 0x09, 0x0a}, /* RTIA 200Ohm */
+    };
+    if(DeRload < HSTIADERLOAD_OPEN)
+      tempreg = (uint32_t)(DeRtiaTable[DeRtia][DeRload])<<3;
+    else
+      tempreg = (0x1f)<<3;  /* Set it to HSTIADERTIA_OPEN. This setting is illegal */
+  }
+  /* deal with HSTIA Rload */
+  tempreg |= DeRload;
+  if(DExPin) //DE1
+    AD5940_WriteReg(REG_AFE_DE1RESCON, tempreg);
+  else  //DE0
+    AD5940_WriteReg(REG_AFE_DE0RESCON, tempreg);
+}
+
+/**
+   @brief Initialize High speed TIA amplifier
+   @param pHsTiaCfg: Pointer to configuration structure
+   @return return none.
+*/
+AD5940Err AD5940_HSTIACfgS(HSTIACfg_Type *pHsTiaCfg)
+{
+  uint32_t tempreg;
+  //Check parameters
+  if(pHsTiaCfg == NULL) return AD5940ERR_NULLP;
+    /* Available parameter is 1k, 5k,...,160k, short, OPEN */
+  if(pHsTiaCfg->HstiaDeRtia < HSTIADERTIA_1K)
+    return AD5940ERR_PARA;
+  if(pHsTiaCfg->HstiaDeRtia > HSTIADERTIA_OPEN)
+    return AD5940ERR_PARA;  /* Parameter is invalid */
+
+  if(pHsTiaCfg->HstiaDeRload > HSTIADERLOAD_OPEN)
+    return AD5940ERR_PARA;  /* Available parameter is OPEN, 0R,..., 100R */
+
+  tempreg = 0;
+  tempreg |= pHsTiaCfg->HstiaBias;
+  AD5940_WriteReg(REG_AFE_HSTIACON, tempreg);
+  /* HSRTIACON */
+  /* Calculate CTIA value */
+  tempreg = pHsTiaCfg->HstiaCtia << BITP_AFE_HSRTIACON_CTIACON;
+  tempreg |= pHsTiaCfg->HstiaRtiaSel;
+  if(pHsTiaCfg->DiodeClose == bTRUE)
+    tempreg |= BITM_AFE_HSRTIACON_TIASW6CON; /* Close switch 6 */
+  AD5940_WriteReg(REG_AFE_HSRTIACON, tempreg);
+  /* DExRESCON */
+  __AD5940_SetDExRTIA(0, pHsTiaCfg->HstiaDeRtia, pHsTiaCfg->HstiaDeRload);
+#ifdef CHIPSEL_M355
+  __AD5940_SetDExRTIA(1, pHsTiaCfg->HstiaDe1Rtia, pHsTiaCfg->HstiaDe1Rload);
+#endif
+
+  /* Done */
+  return AD5940ERR_OK;
+}
+/**
+ * @brief Configure HSTIA RTIA resistor and keep other parameters unchanged.
+ * @param HSTIARtia: The RTIA setting, select it from @ref HSTIARTIA_Const
+ * @return return none.
+*/
+void AD5940_HSRTIACfgS(uint32_t HSTIARtia)
+{
+  uint32_t tempreg;
+  tempreg = AD5940_ReadReg(REG_AFE_HSRTIACON);
+  tempreg &= ~BITM_AFE_HSRTIACON_RTIACON;
+  HSTIARtia &= BITM_AFE_HSRTIACON_RTIACON;
+  tempreg |= HSTIARtia<<BITP_AFE_HSRTIACON_RTIACON;
+  AD5940_WriteReg(REG_AFE_HSRTIACON, tempreg);
+}
+
+/**
+ * @defgroup Waveform_Generator_Functions
+ * @{
+*/
+/**
+ * @brief Initialize waveform generator
+ * @param pWGInit: Pointer to configuration structure
+ * @return return none.
+*/
+void AD5940_WGCfgS(WGCfg_Type *pWGInit)
+{
+  //Check parameters
+  uint32_t tempreg;
+  if(pWGInit->WgType == WGTYPE_SIN)
+  {
+    /* Configure Sine wave Generator */
+    AD5940_WriteReg(REG_AFE_WGFCW, pWGInit->SinCfg.SinFreqWord);
+    AD5940_WriteReg(REG_AFE_WGAMPLITUDE, pWGInit->SinCfg.SinAmplitudeWord);
+    AD5940_WriteReg(REG_AFE_WGOFFSET, pWGInit->SinCfg.SinOffsetWord);
+    AD5940_WriteReg(REG_AFE_WGPHASE, pWGInit->SinCfg.SinPhaseWord);
+  }
+  else if(pWGInit->WgType == WGTYPE_TRAPZ)
+  {
+    /* Configure Trapezoid Generator */
+    AD5940_WriteReg(REG_AFE_WGDCLEVEL1, pWGInit->TrapzCfg.WGTrapzDCLevel1);
+    AD5940_WriteReg(REG_AFE_WGDCLEVEL2, pWGInit->TrapzCfg.WGTrapzDCLevel2);
+    AD5940_WriteReg(REG_AFE_WGDELAY1, pWGInit->TrapzCfg.WGTrapzDelay1);
+    AD5940_WriteReg(REG_AFE_WGDELAY2, pWGInit->TrapzCfg.WGTrapzDelay2);
+    AD5940_WriteReg(REG_AFE_WGSLOPE1, pWGInit->TrapzCfg.WGTrapzSlope1);
+    AD5940_WriteReg(REG_AFE_WGSLOPE2, pWGInit->TrapzCfg.WGTrapzSlope2);
+  }
+  else
+  {
+    /* Write DAC data. It's only have effect when WgType set to WGTYPE_MMR */ 
+    AD5940_WriteReg(REG_AFE_HSDACDAT, pWGInit->WgCode);
+  }
+  tempreg = 0;
+  
+  if(pWGInit->GainCalEn == bTRUE)
+    tempreg |= BITM_AFE_WGCON_DACGAINCAL;
+  if(pWGInit->OffsetCalEn == bTRUE)
+    tempreg |= BITM_AFE_WGCON_DACOFFSETCAL;
+  tempreg |= (pWGInit->WgType) << BITP_AFE_WGCON_TYPESEL;
+  AD5940_WriteReg(REG_AFE_WGCON, tempreg);
+}
+
+/**
+ * @brief Write HSDAC code directly when WG configured to MMR type
+ * @param code: The 12-bit HSDAC code.
+ * @return return none.
+*/
+AD5940Err AD5940_WGDACCodeS(uint32_t code)
+{
+  code &= 0xfff;
+  AD5940_WriteReg(REG_AFE_HSDACDAT, code);
+  return AD5940ERR_OK;
+}
+
+/**
+ * @brief Update WG SIN wave frequency in Hz.
+ * @param SinFreqHz: The desired frequency in Hz.
+ * @param WGClock: The clock for WG. It's same as system clock and the default value is internal 16MHz HSOSC.
+ * @return return none.
+*/
+void AD5940_WGFreqCtrlS(float SinFreqHz, float WGClock)
+{
+  uint32_t freq_word;
+  freq_word = AD5940_WGFreqWordCal(SinFreqHz, WGClock);
+  AD5940_WriteReg(REG_AFE_WGFCW, freq_word);
+}
+
+/**
+   @brief Calculate sine wave generator frequency word. The maxim frequency is 250kHz-1LSB
+   @param SinFreqHz : Target frequency in Hz unit.
+   @param WGClock: Waveform generator clock frequency in Hz unit. The clock is sourced from system clock, default value is 16MHz HFOSC.
+   @return return none.
+*/
+uint32_t AD5940_WGFreqWordCal(float SinFreqHz, float WGClock)
+{
+  uint32_t temp;
+  uint32_t __BITWIDTH_WGFCW = 26;
+  if(bIsS2silicon == bTRUE)
+    __BITWIDTH_WGFCW = 30;
+  if(WGClock == 0) return 0;
+  temp = (uint32_t)(SinFreqHz*(1LL<<__BITWIDTH_WGFCW)/WGClock + 0.5f);
+  if(temp > ((__BITWIDTH_WGFCW == 26)?0xfffff:0xffffff))
+    temp = (__BITWIDTH_WGFCW == 26)?0xfffff:0xffffff;
+  
+  return temp;
+}
+
+/**
+ * @} Waveform_Generator_Functions
+ * @} High_Speed_Loop_Functions
+ * @} High_Speed_Loop
+*/
+
+
+/**
+ * @defgroup Low_Power_Loop
+ * @brief The low power loop.
+ * @{
+ *    @defgroup Low_Power_Loop_Functions
+ *    @{
+*/
+
+/**
+   @brief Configure low power loop include LPDAC LPAmp(PA and TIA)
+   @param pLpLoopCfg: Pointer to configure structure;
+   @return return none.
+*/
+void AD5940_LPLoopCfgS(LPLoopCfg_Type *pLpLoopCfg)
+{
+  AD5940_LPDACCfgS(&pLpLoopCfg->LpDacCfg);
+  AD5940_LPAMPCfgS(&pLpLoopCfg->LpAmpCfg);
+}
+
+/**
+   @brief Initialize LPDAC
+   @param pLpDacCfg: Pointer to configuration structure
+   @return return none.
+*/
+void AD5940_LPDACCfgS(LPDACCfg_Type *pLpDacCfg)
+{
+  uint32_t tempreg;
+  tempreg = 0;
+  tempreg = (pLpDacCfg->LpDacSrc)<<BITP_AFE_LPDACCON0_WAVETYPE;
+  tempreg |= (pLpDacCfg->LpDacVzeroMux)<<BITP_AFE_LPDACCON0_VZEROMUX;
+  tempreg |= (pLpDacCfg->LpDacVbiasMux)<<BITP_AFE_LPDACCON0_VBIASMUX;
+  tempreg |= (pLpDacCfg->LpDacRef)<<BITP_AFE_LPDACCON0_REFSEL;
+  if(pLpDacCfg->DataRst == bFALSE)
+    tempreg |= BITM_AFE_LPDACCON0_RSTEN;
+  if(pLpDacCfg->PowerEn == bFALSE)
+    tempreg |= BITM_AFE_LPDACCON0_PWDEN;
+  if(pLpDacCfg->LpdacSel == LPDAC0)
+  {
+    AD5940_WriteReg(REG_AFE_LPDACCON0, tempreg);
+    AD5940_LPDAC0WriteS(pLpDacCfg->DacData12Bit, pLpDacCfg->DacData6Bit);
+    AD5940_WriteReg(REG_AFE_LPDACSW0, pLpDacCfg->LpDacSW|BITM_AFE_LPDACSW0_LPMODEDIS);  /* Overwrite LPDACSW settings. On Si1, this register is not accessible. */
+  }
+  else
+  {
+    AD5940_WriteReg(REG_AFE_LPDACCON1, tempreg);
+    AD5940_LPDAC1WriteS(pLpDacCfg->DacData12Bit, pLpDacCfg->DacData6Bit);
+    AD5940_WriteReg(REG_AFE_LPDACSW1, pLpDacCfg->LpDacSW|BITM_AFE_LPDACSW0_LPMODEDIS);  /* Overwrite LPDACSW settings. On Si1, this register is not accessible. */
+  }
+}
+
+/**
+   @brief Write LPDAC data
+   @param Data12Bit: 12Bit DAC data
+   @param Data6Bit: 6Bit DAC data
+   @return return none.
+*/
+void AD5940_LPDACWriteS(uint16_t Data12Bit, uint8_t Data6Bit)
+{
+  /* Check parameter */
+  Data6Bit &= 0x3f;
+  Data12Bit &= 0xfff;
+  AD5940_WriteReg(REG_AFE_LPDACDAT0, ((uint32_t)Data6Bit<<12)|Data12Bit);
+}
+
+/**
+   @brief Write LPDAC0 data
+   @param Data12Bit: 12Bit DAC data
+   @param Data6Bit: 6Bit DAC data
+   @return return none.
+*/
+void AD5940_LPDAC0WriteS(uint16_t Data12Bit, uint8_t Data6Bit)
+{
+  /* Check parameter */
+  Data6Bit &= 0x3f;
+  Data12Bit &= 0xfff;
+  AD5940_WriteReg(REG_AFE_LPDACDAT0, ((uint32_t)Data6Bit<<12)|Data12Bit);
+}
+
+/**
+   @brief Write LPDAC1 data
+   @param Data12Bit: 12Bit DAC data
+   @param Data6Bit: 6Bit DAC data
+   @return return none.
+*/
+void AD5940_LPDAC1WriteS(uint16_t Data12Bit, uint8_t Data6Bit)
+{
+  /* Check parameter */
+  Data6Bit &= 0x3f;
+  Data12Bit &= 0xfff;
+  AD5940_WriteReg(REG_AFE_LPDACDAT1, ((uint32_t)Data6Bit<<12)|Data12Bit);
+}
+
+/**
+   @brief Initialize LP TIA and PA
+   @param pLpAmpCfg: Pointer to configuration structure
+   @return return none.
+*/
+void AD5940_LPAMPCfgS(LPAmpCfg_Type *pLpAmpCfg)
+{
+  //check parameters
+  uint32_t tempreg;
+
+  tempreg = 0;
+  if(pLpAmpCfg->LpPaPwrEn == bFALSE)
+    tempreg |= BITM_AFE_LPTIACON0_PAPDEN; 
+  if(pLpAmpCfg->LpTiaPwrEn == bFALSE)
+    tempreg |= BITM_AFE_LPTIACON0_TIAPDEN;
+  if(pLpAmpCfg->LpAmpPwrMod == LPAMPPWR_HALF) 
+    tempreg |= BITM_AFE_LPTIACON0_HALFPWR;
+  else
+  {
+    tempreg |= pLpAmpCfg->LpAmpPwrMod<<BITP_AFE_LPTIACON0_IBOOST;
+  }
+  tempreg |= pLpAmpCfg->LpTiaRtia<<BITP_AFE_LPTIACON0_TIAGAIN;
+  tempreg |= pLpAmpCfg->LpTiaRload<<BITP_AFE_LPTIACON0_TIARL;
+  tempreg |= pLpAmpCfg->LpTiaRf<<BITP_AFE_LPTIACON0_TIARF;
+  if(pLpAmpCfg->LpAmpSel == LPAMP0)
+  {
+    AD5940_WriteReg(REG_AFE_LPTIACON0, tempreg);
+    AD5940_WriteReg(REG_AFE_LPTIASW0, pLpAmpCfg->LpTiaSW);
+  }
+  else
+  {
+    AD5940_WriteReg(REG_AFE_LPTIACON1, tempreg);
+    AD5940_WriteReg(REG_AFE_LPTIASW1, pLpAmpCfg->LpTiaSW);
+  }
+}
+/**
+ * @} Low_Power_Loop_Functions
+ * @} Low_Power_Loop
+*/
+
+
+/**
+ * @defgroup DSP_Block
+ * @brief DSP block includes ADC, filters, DFT and statistic functions. 
+ * @{
+ *    @defgroup DSP_Block_Functions
+ *    @{
+ * */
+
+/**
+   @brief Configure low power loop include LPDAC LPAmp(PA and TIA)
+   @param pDSPCfg: Pointer to configure structure;
+   @return return none.
+*/
+void AD5940_DSPCfgS(DSPCfg_Type *pDSPCfg)
+{
+  AD5940_ADCBaseCfgS(&pDSPCfg->ADCBaseCfg);
+  AD5940_ADCFilterCfgS(&pDSPCfg->ADCFilterCfg);
+  AD5940_ADCDigCompCfgS(&pDSPCfg->ADCDigCompCfg);
+  AD5940_DFTCfgS(&pDSPCfg->DftCfg);
+  AD5940_StatisticCfgS(&pDSPCfg->StatCfg);
+}
+
+/**
+   @brief Read AD5940 generated data like ADC and DFT etc.
+   @param AfeResultSel: available parameters are @ref AFERESULT_Const
+          - AFERESULT_SINC3: Read SINC3 filter data result
+          - AFERESULT_SINC2: Read SINC2+NOTCH filter result, when Notch filter is bypassed, the result is SINC2
+          - AFERESULT_STATSVAR: Statistic variance result
+   @return return data read back.
+*/
+uint32_t AD5940_ReadAfeResult(uint32_t AfeResultSel)
+{
+  uint32_t rd = 0;
+  //PARA_CHECK((AfeResultSel));
+  switch (AfeResultSel)
+  {
+    case AFERESULT_SINC3:
+      rd = AD5940_ReadReg(REG_AFE_ADCDAT);
+      break;
+    case AFERESULT_SINC2:
+      rd = AD5940_ReadReg(REG_AFE_SINC2DAT);
+      break;
+    case AFERESULT_TEMPSENSOR:
+      rd = AD5940_ReadReg(REG_AFE_TEMPSENSDAT);
+      break;
+    case AFERESULT_DFTREAL:
+      rd = AD5940_ReadReg(REG_AFE_DFTREAL);
+      break;
+    case AFERESULT_DFTIMAGE:
+      rd = AD5940_ReadReg(REG_AFE_DFTIMAG);
+      break;
+    case AFERESULT_STATSMEAN:
+      rd = AD5940_ReadReg(REG_AFE_STATSMEAN);
+      break;
+    case AFERESULT_STATSVAR:
+      rd = AD5940_ReadReg(REG_AFE_STATSVAR);
+      break;
+  }
+  
+  return rd;
+}
+
+/**
+ *  @defgroup ADC_Block_Functions
+ *  @{
+*/
+
+/**
+   @brief Initializes ADC peripheral according to the specified parameters in the pADCInit.
+   @param pADCInit: Pointer to ADC initialize structure.
+   @return return none.
+*/
+void AD5940_ADCBaseCfgS(ADCBaseCfg_Type *pADCInit)
+{
+  uint32_t tempreg = 0;
+  //PARA_CHECK(IS_ADCMUXP(pADCInit->ADCMuxP));
+  //PARA_CHECK(IS_ADCMUXN(pADCInit->ADCMuxN));
+  PARA_CHECK(IS_ADCPGA(pADCInit->ADCPga));
+  PARA_CHECK(IS_ADCAAF(pADCInit->ADCAAF));
+
+  tempreg = pADCInit->ADCMuxP;
+  tempreg |= (uint32_t)(pADCInit->ADCMuxN)<<BITP_AFE_ADCCON_MUXSELN;
+  //if(pADCInit->OffCancEnable == bTRUE)
+  //  tempreg |= BITM_AFE_ADCCON_GNOFSELPGA;
+  tempreg |= (uint32_t)(pADCInit->ADCPga)<<BITP_AFE_ADCCON_GNPGA;
+
+  AD5940_WriteReg(REG_AFE_ADCCON, tempreg);
+}
+
+/**
+   @brief Initializes ADC filter according to the specified parameters in the pFiltCfg.
+   @param pFiltCfg: Pointer to filter initialize structure.
+   @return return none.
+*/
+void AD5940_ADCFilterCfgS(ADCFilterCfg_Type *pFiltCfg)
+{
+  uint32_t tempreg;
+  PARA_CHECK(IS_ADCSINC3OSR(pFiltCfg->ADCSinc3Osr));
+  PARA_CHECK(IS_ADCSINC2OSR(pFiltCfg->ADCSinc2Osr));
+  PARA_CHECK(IS_ADCAVGNUM(pFiltCfg->ADCAvgNum));
+  PARA_CHECK(IS_ADCRATE(pFiltCfg->ADCRate));
+
+  tempreg = AD5940_ReadReg(REG_AFE_ADCFILTERCON);
+  tempreg &= BITM_AFE_ADCFILTERCON_AVRGEN; /* Keep this bit setting. */
+
+  tempreg |= pFiltCfg->ADCRate;
+  if(pFiltCfg->BpNotch == bTRUE)
+    tempreg |= BITM_AFE_ADCFILTERCON_LPFBYPEN;
+  if(pFiltCfg->BpSinc3 == bTRUE)
+    tempreg |= BITM_AFE_ADCFILTERCON_SINC3BYP;
+  /**
+   * Average filter is enabled when DFT source is @ref DFTSRC_AVG in function @ref AD5940_DFTCfgS.
+   * Once average function is enabled, it's automatically set as DFT source, register DFTCON.DFTINSEL is ignored.
+   */
+  //if(pFiltCfg->AverageEnable == bTRUE)
+  //  tempreg |= BITM_AFE_ADCFILTERCON_AVRGEN;
+  tempreg |= (uint32_t)(pFiltCfg->ADCSinc2Osr)<<BITP_AFE_ADCFILTERCON_SINC2OSR;
+  tempreg |= (uint32_t)(pFiltCfg->ADCSinc3Osr)<<BITP_AFE_ADCFILTERCON_SINC3OSR;
+  tempreg |= (uint32_t)(pFiltCfg->ADCAvgNum)<<BITP_AFE_ADCFILTERCON_AVRGNUM;
+
+  AD5940_WriteReg(REG_AFE_ADCFILTERCON, tempreg);
+
+  /* SINC2+Notch has a block enable/disable bit in AFECON register */
+  if(pFiltCfg->Sinc2NotchEnable)
+  {
+    AD5940_AFECtrlS(AFECTRL_SINC2NOTCH,bTRUE);
+  }
+}
+
+/**
+   @brief Power up or power down ADC block(including ADC PGA and FRONTBUF).
+   @param State : {bTRUE, bFALSE}
+          - bTRUE: Power up ADC
+          - bFALSE: Power down ADC
+   @return return none.
+*/
+void AD5940_ADCPowerCtrlS(BoolFlag State)
+{
+  uint32_t tempreg;
+  tempreg = AD5940_ReadReg(REG_AFE_AFECON);
+  if(State == bTRUE)
+  {
+    tempreg |= BITM_AFE_AFECON_ADCEN;
+  }
+  else
+  {
+    tempreg &= ~BITM_AFE_AFECON_ADCEN;
+  }
+  AD5940_WriteReg(REG_AFE_AFECON,tempreg);
+}
+
+/**
+   @brief Start or stop ADC convert.
+   @param State : {bTRUE, bFALSE}
+          - bTRUE: Start ADC convert
+          - bFALSE: Stop ADC convert
+   @return return none.
+*/
+void AD5940_ADCConvtCtrlS(BoolFlag State)
+{
+  uint32_t tempreg;
+  tempreg = AD5940_ReadReg(REG_AFE_AFECON);
+  if(State == bTRUE)
+  {
+    tempreg |= BITM_AFE_AFECON_ADCCONVEN;
+  }
+  else
+  {
+    tempreg &= ~BITM_AFE_AFECON_ADCCONVEN;
+  }
+  AD5940_WriteReg(REG_AFE_AFECON,tempreg);
+}
+
+/**
+   @brief Configure ADC input MUX
+   @param ADCMuxP : {ADCMUXP_FLOAT, ADCMUXP_HSTIA_P, ,,, ,ADCMUXP_P_NODE}
+          - ADCMUXP_FLOAT: float ADC MUX positive input
+          - ADCMUXP_HSTIA_P: High speed TIA output sense terminal
+          - ADCMUXP_P_NODE: Excitation loop P node
+   @param ADCMuxN : {ADCMUXP_FLOAT, ADCMUXP_HSTIA_P, ,,, ,ADCMUXP_P_NODE}
+          - ADCMUXP_FLOAT: float ADC MUX positive input
+          - ADCMUXP_HSTIA_P: High speed TIA output sense terminal
+          - ADCMUXP_P_NODE: Excitation loop P node
+
+   @return return none.
+*/
+void AD5940_ADCMuxCfgS(uint32_t ADCMuxP, uint32_t ADCMuxN)
+{
+  uint32_t tempreg;
+  //PARA_CHECK(IS_ADCMUXP(ADCMuxP));
+  //PARA_CHECK(IS_ADCMUXN(ADCMuxN));
+  
+  tempreg = AD5940_ReadReg(REG_AFE_ADCCON);
+  tempreg &= ~(BITM_AFE_ADCCON_MUXSELN|BITM_AFE_ADCCON_MUXSELP);
+  tempreg |= ADCMuxP<<BITP_AFE_ADCCON_MUXSELP;
+  tempreg |= ADCMuxN<<BITP_AFE_ADCCON_MUXSELN;
+  AD5940_WriteReg(REG_AFE_ADCCON, tempreg);
+}
+
+/**
+   @brief Set ADC digital comparator function
+   @param pCompCfg: Pointer to configuration structure
+   @return return none.
+*/
+void AD5940_ADCDigCompCfgS(ADCDigComp_Type *pCompCfg)
+{
+  //PARA_CHECK((AfeResultSel));
+  AD5940_WriteReg(REG_AFE_ADCMIN, pCompCfg->ADCMin);
+  AD5940_WriteReg(REG_AFE_ADCMINSM, pCompCfg->ADCMinHys);
+  AD5940_WriteReg(REG_AFE_ADCMAX, pCompCfg->ADCMax);
+  AD5940_WriteReg(REG_AFE_ADCMAXSMEN, pCompCfg->ADCMaxHys);
+}
+/** @} ADC_Block_Functions */
+
+/**
+   @brief Configure statistic functions
+   @param pStatCfg: Pointer to configuration structure
+   @return return none.
+*/
+void AD5940_StatisticCfgS(StatCfg_Type *pStatCfg)
+{
+  uint32_t tempreg;
+  //check parameters
+  tempreg = 0;
+  if(pStatCfg->StatEnable == bTRUE)
+    tempreg |= BITM_AFE_STATSCON_STATSEN;
+  tempreg |= (pStatCfg->StatSample) << BITP_AFE_STATSCON_SAMPLENUM;
+  tempreg |= (pStatCfg->StatDev) << BITP_AFE_STATSCON_STDDEV;
+  AD5940_WriteReg(REG_AFE_STATSCON, tempreg);
+}
+
+/**
+ * @brief Set ADC Repeat convert function number. Turn off ADC automatically after Number samples of ADC raw data are ready
+ * @param Number: Specify after how much ADC raw data need to sample before shutdown ADC
+ * @return return none.
+*/
+void AD5940_ADCRepeatCfgS(uint32_t Number)
+{
+  //check parameter if(number<255)
+  AD5940_WriteReg(REG_AFE_REPEATADCCNV, Number<<BITP_AFE_REPEATADCCNV_NUM);
+}
+
+/**
+   @brief Configure DFT number and source and hanning window
+   @param pDftCfg: Pointer to configuration structure
+   @return return none.
+*/
+void AD5940_DFTCfgS(DFTCfg_Type *pDftCfg)
+{
+  uint32_t reg_dftcon, reg_adcfilter;
+
+  reg_dftcon = 0;
+  /* Deal with DFTSRC_AVG. Once average function is enabled, it's automatically set as DFT source */
+  reg_adcfilter = AD5940_ReadReg(REG_AFE_ADCFILTERCON);
+  if(pDftCfg->DftSrc == DFTSRC_AVG)
+  {
+    reg_adcfilter |= BITM_AFE_ADCFILTERCON_AVRGEN;
+    AD5940_WriteReg(REG_AFE_ADCFILTERCON, reg_adcfilter);
+  }
+  else
+  {
+    /* Disable Average function and set correct DFT source */
+    reg_adcfilter &= ~BITM_AFE_ADCFILTERCON_AVRGEN;
+    AD5940_WriteReg(REG_AFE_ADCFILTERCON, reg_adcfilter);
+
+    /* Set new DFT source */
+    reg_dftcon |= (pDftCfg->DftSrc) << BITP_AFE_DFTCON_DFTINSEL;
+  }
+  /* Set DFT number */
+  reg_dftcon |= (pDftCfg->DftNum) << BITP_AFE_DFTCON_DFTNUM;
+  
+  if(pDftCfg->HanWinEn == bTRUE)
+    reg_dftcon |= BITM_AFE_DFTCON_HANNINGEN;
+  AD5940_WriteReg(REG_AFE_DFTCON, reg_dftcon);
+}
+
+/**
+ * @} DSP_Block_Functions
+ * @} DSP_Block
+*/
+
+/**
+ * @defgroup Sequencer_FIFO
+ * @brief Sequencer and FIFO.
+ * @{
+ *    @defgroup Sequencer_FIFO_Functions
+ *    @{
+*/
+
+/**
+   @brief Configure AD5940 FIFO
+   @param pFifoCfg: Pointer to configuration structure.
+   @return return none.
+*/
+void AD5940_FIFOCfg(FIFOCfg_Type *pFifoCfg)
+{
+  uint32_t tempreg;
+  //check parameters
+  AD5940_WriteReg(REG_AFE_FIFOCON, 0);  /* Disable FIFO firstly! */
+  /* CMDDATACON register. Configure this firstly */
+  tempreg = AD5940_ReadReg(REG_AFE_CMDDATACON);
+  tempreg &= BITM_AFE_CMDDATACON_CMD_MEM_SEL|BITM_AFE_CMDDATACON_CMDMEMMDE; /* Keep sequencer memory settings */
+  tempreg |= pFifoCfg->FIFOMode << BITP_AFE_CMDDATACON_DATAMEMMDE; 				  /* Data FIFO mode: stream or FIFO */
+  tempreg |= pFifoCfg->FIFOSize << BITP_AFE_CMDDATACON_DATA_MEM_SEL;  		  /* Data FIFO memory size */
+  /* The reset memory can be used for sequencer, configure it by function AD5940_SEQCfg() */
+  AD5940_WriteReg(REG_AFE_CMDDATACON, tempreg);
+
+  /* FIFO Threshold */
+  AD5940_WriteReg(REG_AFE_DATAFIFOTHRES, pFifoCfg->FIFOThresh << BITP_AFE_DATAFIFOTHRES_HIGHTHRES);
+  /* FIFOCON register. Final step is to enable FIFO */
+  tempreg = 0;
+  if(pFifoCfg->FIFOEn == bTRUE)
+    tempreg |= BITM_AFE_FIFOCON_DATAFIFOEN;																/* Enable FIFO after everything set. */
+  tempreg |= pFifoCfg->FIFOSrc << BITP_AFE_FIFOCON_DATAFIFOSRCSEL;
+  AD5940_WriteReg(REG_AFE_FIFOCON, tempreg);
+}
+
+/**
+   @brief Read current FIFO configuration.
+   @param pFifoCfg: Pointer to a buffer that used to store FIFO configuration.
+   @return return AD5940ERR_OK if succeed.
+*/
+AD5940Err AD5940_FIFOGetCfg(FIFOCfg_Type *pFifoCfg)
+{
+  uint32_t tempreg;
+  //check parameters
+  if(pFifoCfg == NULL) return AD5940ERR_NULLP;
+  /* CMDDATACON register. */
+  tempreg = AD5940_ReadReg(REG_AFE_CMDDATACON);
+  pFifoCfg->FIFOMode = (tempreg&BITM_AFE_CMDDATACON_DATAMEMMDE)>>BITP_AFE_CMDDATACON_DATAMEMMDE;
+  pFifoCfg->FIFOSize = (tempreg&BITM_AFE_CMDDATACON_DATA_MEM_SEL)>>BITP_AFE_CMDDATACON_DATA_MEM_SEL;
+
+  /* FIFO Threshold */
+  tempreg = AD5940_ReadReg(REG_AFE_DATAFIFOTHRES);
+  pFifoCfg->FIFOThresh = (tempreg&BITM_AFE_DATAFIFOTHRES_HIGHTHRES)>>BITP_AFE_DATAFIFOTHRES_HIGHTHRES;
+  /* FIFOCON register. */
+  tempreg = AD5940_ReadReg(REG_AFE_FIFOCON);
+  pFifoCfg->FIFOEn = (tempreg&BITM_AFE_FIFOCON_DATAFIFOEN)?bTRUE:bFALSE;
+  pFifoCfg->FIFOSrc = (tempreg&BITM_AFE_FIFOCON_DATAFIFOSRCSEL)>>BITP_AFE_FIFOCON_DATAFIFOSRCSEL;
+
+  return AD5940ERR_OK;
+}
+
+/**
+ * @brief Configure AD5940 FIFO Source and enable or disable FIFO.
+ * @param FifoSrc : available choices are @ref FIFOSRC_Const 
+ *      - FIFOSRC_SINC3       SINC3 data
+ *      - FIFOSRC_DFT         DFT real and imaginary part 
+ *      - FIFOSRC_SINC2NOTCH  SINC2+NOTCH block. Notch can be bypassed, so SINC2 data can be feed to FIFO 
+ *      - FIFOSRC_VAR         Statistic variance output 
+ *      - FIFOSRC_MEAN        Statistic mean output
+ * @param FifoEn: enable or disable the FIFO.
+ * @return return none.
+*/
+void AD5940_FIFOCtrlS(uint32_t FifoSrc, BoolFlag FifoEn)
+{
+  uint32_t tempreg;
+
+  tempreg = 0;
+  if(FifoEn == bTRUE)
+    tempreg |= BITM_AFE_FIFOCON_DATAFIFOEN;
+  tempreg |= FifoSrc << BITP_AFE_FIFOCON_DATAFIFOSRCSEL;
+  AD5940_WriteReg(REG_AFE_FIFOCON, tempreg);
+}
+
+/**
+ * @brief Configure AD5940 Data FIFO threshold value
+   @param FIFOThresh: FIFO threshold value
+   @return return none.
+*/
+void AD5940_FIFOThrshSet(uint32_t FIFOThresh)
+{
+  /* FIFO Threshold */
+  AD5940_WriteReg(REG_AFE_DATAFIFOTHRES, FIFOThresh << BITP_AFE_DATAFIFOTHRES_HIGHTHRES);
+}
+
+/**
+ * @brief Get Data count in FIFO
+ * @return return none.
+*/
+uint32_t AD5940_FIFOGetCnt(void)
+{
+  return AD5940_ReadReg(REG_AFE_FIFOCNTSTA) >> BITP_AFE_FIFOCNTSTA_DATAFIFOCNTSTA;
+}
+
+
+/* Sequencer */
+/**
+ * @brief Initialize Sequencer
+ * @param pSeqCfg: Pointer to configuration structure
+   @return return none.
+*/
+void AD5940_SEQCfg(SEQCfg_Type *pSeqCfg)
+{
+  /* check parameters */
+  uint32_t tempreg, fifocon;
+  
+  fifocon = AD5940_ReadReg(REG_AFE_FIFOCON);
+  AD5940_WriteReg(REG_AFE_FIFOCON, 0);  /* Disable FIFO before changing memory configuration */
+  /* Configure CMDDATACON register */
+  tempreg = AD5940_ReadReg(REG_AFE_CMDDATACON);
+  tempreg &= ~(BITM_AFE_CMDDATACON_CMDMEMMDE|BITM_AFE_CMDDATACON_CMD_MEM_SEL);  /* Clear settings for sequencer memory */
+  tempreg |= (1L) << BITP_AFE_CMDDATACON_CMDMEMMDE;    										  /* Sequencer is always in memory mode */ 
+  tempreg |= (pSeqCfg->SeqMemSize) << BITP_AFE_CMDDATACON_CMD_MEM_SEL; 	
+  AD5940_WriteReg(REG_AFE_CMDDATACON, tempreg);
+
+  if(pSeqCfg->SeqCntCRCClr)
+  {
+    AD5940_WriteReg(REG_AFE_SEQCON, 0);  /* Disable sequencer firstly */
+    AD5940_WriteReg(REG_AFE_SEQCNT, 0);  /* When sequencer is disabled, any write to SEQCNT will clear CNT and CRC register */  
+  }
+  tempreg = 0;
+  if(pSeqCfg->SeqEnable == bTRUE)
+    tempreg |= BITM_AFE_SEQCON_SEQEN;
+  tempreg |= (pSeqCfg->SeqWrTimer) << BITP_AFE_SEQCON_SEQWRTMR;
+  AD5940_WriteReg(REG_AFE_SEQCON, tempreg);
+  AD5940_WriteReg(REG_AFE_FIFOCON, fifocon);  /* restore FIFO configuration */
+
+  // tempreg = 0;
+  // if(pSeqCfg->SeqBreakEn)
+  //   tempreg |= 0x01;  // add register definition? bitm_afe_
+  // if(pSeqCfg->SeqIgnoreEn)
+  //   tempreg |= 0x02;  
+  // AD5940_WriteReg(0x21dc, tempreg);
+}
+/**
+ * @brief Read back current sequencer configuration and store it to pSeqCfg
+ * @param pSeqCfg: Pointer to structure
+ * @return return AD5940ERR_OK if succeed.
+*/
+AD5940Err AD5940_SEQGetCfg(SEQCfg_Type *pSeqCfg)
+{
+  /* check parameters */
+  uint32_t tempreg;
+  if(pSeqCfg == NULL)
+    return AD5940ERR_NULLP;
+  /* Read CMDDATACON register */
+  tempreg = AD5940_ReadReg(REG_AFE_CMDDATACON);
+  pSeqCfg->SeqMemSize = (tempreg&BITM_AFE_CMDDATACON_CMD_MEM_SEL) >> BITP_AFE_CMDDATACON_CMD_MEM_SEL;
+  pSeqCfg->SeqCntCRCClr = bFALSE; /* Has no meaning */
+  /* SEQCON register */
+  tempreg = AD5940_ReadReg(REG_AFE_SEQCON);
+  pSeqCfg->SeqEnable = (tempreg&BITM_AFE_SEQCON_SEQEN)?bTRUE:bFALSE;
+  pSeqCfg->SeqWrTimer = (tempreg&BITM_AFE_SEQCON_SEQWRTMR) >> BITP_AFE_SEQCON_SEQWRTMR;
+  return AD5940ERR_OK;
+}
+
+/**
+ * @brief Enable or Disable sequencer. 
+ * @note Only after valid trigger signal, sequencer can run.
+ * @return return none.
+*/
+void AD5940_SEQCtrlS(BoolFlag SeqEn)
+{
+  uint32_t tempreg = AD5940_ReadReg(REG_AFE_SEQCON);
+  if(SeqEn == bTRUE)
+    tempreg |= BITM_AFE_SEQCON_SEQEN;
+  else
+    tempreg &= ~BITM_AFE_SEQCON_SEQEN;
+
+  AD5940_WriteReg(REG_AFE_SEQCON, tempreg);
+}
+
+/**
+ * @brief Halt sequencer immediately. Use this to debug. In normal application, there is no situation that can use this function.
+ * @return return none.
+*/
+void AD5940_SEQHaltS(void)
+{
+  AD5940_WriteReg(REG_AFE_SEQCON, BITM_AFE_SEQCON_SEQHALT|BITM_AFE_SEQCON_SEQEN);
+}
+
+/**
+ * @brief Trigger sequencer by register write.
+ * @return return none.
+**/
+void AD5940_SEQMmrTrig(uint32_t SeqId)
+{
+  if(SeqId > SEQID_3)
+    return;
+  AD5940_WriteReg(REG_AFECON_TRIGSEQ, 1L<<SeqId);
+}
+
+/**
+ * @brief Write sequencer commands to AD5940 SRAM.
+ * @return return none.
+**/
+void AD5940_SEQCmdWrite(uint32_t StartAddr, const uint32_t *pCommand, uint32_t CmdCnt)
+{
+  while(CmdCnt--)
+  {
+    AD5940_WriteReg(REG_AFE_CMDFIFOWADDR, StartAddr++);
+    AD5940_WriteReg(REG_AFE_CMDFIFOWRITE, *pCommand++);
+  }
+}
+
+/**
+   @brief Initialize Sequence INFO. 
+   @details There are four set of registers that record sequence information. 
+          The info contains command start address in SRAM and sequence length. 
+          Hardware can automatically manage these four sequences. If the application 
+          requires more than 4 sequences, user should manually record the sequence 
+          Info(address and length) in MCU.
+   @param pSeq: Pointer to configuration structure. Specify sequence start address in SRAM and sequence length.
+   @return return none.
+*/
+void AD5940_SEQInfoCfg(SEQInfo_Type *pSeq)
+{
+  switch(pSeq->SeqId)
+  {
+    case SEQID_0:
+    /* Configure SEQINFO register */
+    AD5940_WriteReg(REG_AFE_SEQ0INFO, (pSeq->SeqLen<< 16) | pSeq->SeqRamAddr);
+    break;
+    case SEQID_1:
+    AD5940_WriteReg(REG_AFE_SEQ1INFO, (pSeq->SeqLen<< 16) | pSeq->SeqRamAddr);
+    break;
+    case SEQID_2:
+    AD5940_WriteReg(REG_AFE_SEQ2INFO, (pSeq->SeqLen<< 16) | pSeq->SeqRamAddr);
+    break;
+    case SEQID_3:
+    AD5940_WriteReg(REG_AFE_SEQ3INFO, (pSeq->SeqLen<< 16) | pSeq->SeqRamAddr);
+    break;
+    default:
+    break;
+  }
+  if(pSeq->WriteSRAM == bTRUE)
+  {
+    AD5940_SEQCmdWrite(pSeq->SeqRamAddr, pSeq->pSeqCmd, pSeq->SeqLen);
+  }
+}
+
+/**
+ * @brief Get sequence info: start address and sequence length.
+ * @param SeqId: Select from {SEQID_0, SEQID_1, SEQID_2, SEQID_3}
+          - Select which sequence we want to get the information. 
+   @param pSeqInfo: Pointer to sequence info structure. 
+   @return return AD5940ERR_OK when succeed.
+*/
+AD5940Err AD5940_SEQInfoGet(uint32_t SeqId, SEQInfo_Type *pSeqInfo)
+{
+  uint32_t tempreg;
+  if(pSeqInfo == NULL) return AD5940ERR_NULLP;
+  switch(SeqId)
+  {
+    case SEQID_0:
+    tempreg = AD5940_ReadReg(REG_AFE_SEQ0INFO);
+    break;
+    case SEQID_1:
+    tempreg = AD5940_ReadReg(REG_AFE_SEQ1INFO);
+    break;
+    case SEQID_2:
+    tempreg = AD5940_ReadReg(REG_AFE_SEQ2INFO);
+    break;
+    case SEQID_3:
+    tempreg = AD5940_ReadReg(REG_AFE_SEQ3INFO);
+    break;
+    default:
+			return AD5940ERR_PARA;
+  }
+  pSeqInfo->pSeqCmd = 0;    /* We don't know where you store the sequence in MCU SRAM */
+  pSeqInfo->SeqId = SeqId;
+  pSeqInfo->SeqLen = (tempreg>>16)&0x7ff;
+  pSeqInfo->SeqRamAddr = tempreg&0x7ff;
+  pSeqInfo->WriteSRAM = bFALSE;  /* Don't care */
+
+  return AD5940ERR_OK;
+}
+
+
+/**
+   @brief Control GPIO with register SYNCEXTDEVICE. Because sequencer have no ability to access register GPIOOUT,
+         so we use this register for sequencer.
+   @param Gpio : Select from {AGPIO_Pin0|AGPIO_Pin1|AGPIO_Pin2|AGPIO_Pin3|AGPIO_Pin4|AGPIO_Pin5|AGPIO_Pin6|AGPIO_Pin7}
+          - The combination of GPIO pins. The selected pins will be set to High. Others will be pulled low.
+   @return return None.
+
+**/
+void AD5940_SEQGpioCtrlS(uint32_t Gpio)
+{
+  AD5940_WriteReg(REG_AFE_SYNCEXTDEVICE, Gpio);
+}
+
+/**
+ * @brief Read back current count down timer value for Sequencer Timer Out command.
+ * @return return register value of Sequencer Timer out value.
+**/
+uint32_t AD5940_SEQTimeOutRd(void)
+{
+  return AD5940_ReadReg(REG_AFE_SEQTIMEOUT);
+}
+
+/**
+ * @brief Configure GPIO to allow it to trigger corresponding sequence(SEQ0/1/2/3).
+ * @details There are four sequences. We can use GPIO to trigger each sequence. For example,
+ *          GP0 or GP4 can be used to trigger sequence0 and GP3 or GP7 to trigger sequence3.
+ *          There are five mode available to detect pin action: Rising edge, falling edge, both rising and falling
+ *          edge, low level or high level.
+ *          Be careful to use level detection. The trigger signal is always available if the pin level is matched.
+ *          Once the sequence is done, it will immediately run again if the pin level is still matched.
+ * @return return AD5940ERR_OK if succeed.
+**/
+AD5940Err AD5940_SEQGpioTrigCfg(SeqGpioTrig_Cfg *pSeqGpioTrigCfg)
+{
+  uint32_t reg_ei0con, reg_ei1con;
+  uint32_t pin_count, pin_mask;
+  uint32_t mode, en;
+  if(pSeqGpioTrigCfg == NULL)
+    return AD5940ERR_NULLP;
+  reg_ei0con = AD5940_ReadReg(REG_ALLON_EI0CON);
+  reg_ei1con = AD5940_ReadReg(REG_ALLON_EI1CON);
+
+  pin_count = 0;    /* Start from pin0 */
+  pin_mask = 0x01;  /* start from pin0, mask 0x01 */
+  pSeqGpioTrigCfg->SeqPinTrigMode &= 0x07;  /* 3bit width */
+
+  mode = pSeqGpioTrigCfg->SeqPinTrigMode;
+  en = pSeqGpioTrigCfg->bEnable?1:0;
+  for(;;)
+  {
+    uint32_t bit_position;
+    if(pSeqGpioTrigCfg->PinSel&pin_mask)
+    {
+      if(pin_count < 4) /* EI0CON register */
+      {
+        bit_position = pin_count*4;
+        reg_ei1con &= ~(0xfL<<bit_position); /* Clear bits */
+        reg_ei1con |= mode << bit_position;
+        reg_ei1con |= en << (bit_position + 3); /* bit offset 3 is the EN bit. */
+      }
+      else
+      {
+        bit_position = (pin_count-4)*4;
+        reg_ei1con &= ~(0xfL<<bit_position); /* Clear bits */
+        reg_ei1con |= mode << bit_position;
+        reg_ei1con |= en << (bit_position + 3); /* bit offset 3 is the EN bit. */
+      }
+    }
+    pin_count ++;
+    pin_mask <<= 1;
+    if(pin_count == 8)
+      break;
+  }
+  AD5940_WriteReg(REG_ALLON_EI0CON, reg_ei0con);
+  AD5940_WriteReg(REG_ALLON_EI0CON, reg_ei1con);
+  return AD5940ERR_OK;
+}
+
+/**
+ * @brief Configure Wakeup Timer
+ * @param pWuptCfg: Pointer to configuration structure.
+ * @return return none.
+*/
+void AD5940_WUPTCfg(WUPTCfg_Type *pWuptCfg)
+{
+  uint32_t tempreg;
+  //check parameters
+  /* Sleep and Wakeup time */
+  AD5940_WriteReg(REG_WUPTMR_SEQ0WUPL, (pWuptCfg->SeqxWakeupTime[0] & 0xFFFF));    
+  AD5940_WriteReg(REG_WUPTMR_SEQ0WUPH, (pWuptCfg->SeqxWakeupTime[0] & 0xF0000)>>16);
+  AD5940_WriteReg(REG_WUPTMR_SEQ0SLEEPL, (pWuptCfg->SeqxSleepTime[0] & 0xFFFF));    
+  AD5940_WriteReg(REG_WUPTMR_SEQ0SLEEPH, (pWuptCfg->SeqxSleepTime[0] & 0xF0000)>>16);
+
+  AD5940_WriteReg(REG_WUPTMR_SEQ1WUPL, (pWuptCfg->SeqxWakeupTime[1] & 0xFFFF));    
+  AD5940_WriteReg(REG_WUPTMR_SEQ1WUPH, (pWuptCfg->SeqxWakeupTime[1] & 0xF0000)>>16);
+  AD5940_WriteReg(REG_WUPTMR_SEQ1SLEEPL, (pWuptCfg->SeqxSleepTime[1] & 0xFFFF));    
+  AD5940_WriteReg(REG_WUPTMR_SEQ1SLEEPH, (pWuptCfg->SeqxSleepTime[1] & 0xF0000)>>16);
+
+  AD5940_WriteReg(REG_WUPTMR_SEQ2WUPL, (pWuptCfg->SeqxWakeupTime[2] & 0xFFFF));    
+  AD5940_WriteReg(REG_WUPTMR_SEQ2WUPH, (pWuptCfg->SeqxWakeupTime[2] & 0xF0000)>>16);
+  AD5940_WriteReg(REG_WUPTMR_SEQ2SLEEPL, (pWuptCfg->SeqxSleepTime[2] & 0xFFFF));    
+  AD5940_WriteReg(REG_WUPTMR_SEQ2SLEEPH, (pWuptCfg->SeqxSleepTime[2] & 0xF0000)>>16);
+
+  AD5940_WriteReg(REG_WUPTMR_SEQ3WUPL, (pWuptCfg->SeqxWakeupTime[3] & 0xFFFF));    
+  AD5940_WriteReg(REG_WUPTMR_SEQ3WUPH, (pWuptCfg->SeqxWakeupTime[3] & 0xF0000)>>16);
+  AD5940_WriteReg(REG_WUPTMR_SEQ3SLEEPL, (pWuptCfg->SeqxSleepTime[3] & 0xFFFF));    
+  AD5940_WriteReg(REG_WUPTMR_SEQ3SLEEPH, (pWuptCfg->SeqxSleepTime[3] & 0xF0000)>>16);
+  
+  /* TMRCON register */
+  //if(pWuptCfg->WakeupEn == bTRUE)  /* enable use Wupt to wakeup AFE */
+  /* We always allow Wupt to wakeup AFE automatically. */
+  AD5940_WriteReg(REG_ALLON_TMRCON, BITM_ALLON_TMRCON_TMRINTEN);
+  /* Wupt order */
+  tempreg = 0;
+  tempreg |= (pWuptCfg->WuptOrder[0]&0x03) << BITP_WUPTMR_SEQORDER_SEQA; /* position A */
+  tempreg |= (pWuptCfg->WuptOrder[1]&0x03) << BITP_WUPTMR_SEQORDER_SEQB; /* position B */
+  tempreg |= (pWuptCfg->WuptOrder[2]&0x03) << BITP_WUPTMR_SEQORDER_SEQC; /* position C */
+  tempreg |= (pWuptCfg->WuptOrder[3]&0x03) << BITP_WUPTMR_SEQORDER_SEQD; /* position D */
+  tempreg |= (pWuptCfg->WuptOrder[4]&0x03) << BITP_WUPTMR_SEQORDER_SEQE; /* position E */
+  tempreg |= (pWuptCfg->WuptOrder[5]&0x03) << BITP_WUPTMR_SEQORDER_SEQF; /* position F */
+  tempreg |= (pWuptCfg->WuptOrder[6]&0x03) << BITP_WUPTMR_SEQORDER_SEQG; /* position G */
+  tempreg |= (pWuptCfg->WuptOrder[7]&0x03) << BITP_WUPTMR_SEQORDER_SEQH; /* position H */
+  AD5940_WriteReg(REG_WUPTMR_SEQORDER, tempreg);
+
+  tempreg = 0;
+  if(pWuptCfg->WuptEn == bTRUE)
+    tempreg |= BITM_WUPTMR_CON_EN;
+  /* We always allow Wupt to trigger sequencer */
+  tempreg |= pWuptCfg->WuptEndSeq << BITP_WUPTMR_CON_ENDSEQ;
+  //tempreg |= 1L<<4;
+  AD5940_WriteReg(REG_WUPTMR_CON, tempreg);
+}
+
+/**
+ * @brief Enable or disable wakeup timer
+ * @param Enable : {bTRUE, bFALSE}
+ *        - bTRUE: enable wakeup timer
+ *        - bFALSE: Disable wakeup timer
+ * @return return none.
+*/
+void AD5940_WUPTCtrl(BoolFlag Enable)
+{
+  uint16_t tempreg;
+  tempreg = AD5940_ReadReg(REG_WUPTMR_CON);
+  tempreg &= ~BITM_WUPTMR_CON_EN;
+
+  if(Enable == bTRUE)
+    tempreg |= BITM_WUPTMR_CON_EN;
+  
+  AD5940_WriteReg(REG_WUPTMR_CON, tempreg);
+}
+
+/**
+ * @brief Configure WakeupTimer.
+ * @param SeqId: Select from SEQID_0/1/2/3. The wakeup timer will load corresponding value from four sets of registers.
+ * @param SleepTime: After how much time, AFE will try to enter hibernate. We disabled this feature in AD59840_Initialize. After this timer expired, nothing will happen.
+ * @param WakeupTime: After how much time, AFE will wakeup and trigger corresponding sequencer.
+ * @note By SleepTime and WakeupTime, the sequencer is triggered periodically and period is (SleepTime+WakeupTime)
+ * @return return none.
+*/
+AD5940Err AD5940_WUPTTime(uint32_t SeqId, uint32_t SleepTime, uint32_t WakeupTime)
+{
+  switch (SeqId)
+  {
+    case SEQID_0:
+    {
+      AD5940_WriteReg(REG_WUPTMR_SEQ0WUPL, (WakeupTime & 0xFFFF));    
+      AD5940_WriteReg(REG_WUPTMR_SEQ0WUPH, (WakeupTime & 0xF0000)>>16);
+      AD5940_WriteReg(REG_WUPTMR_SEQ0SLEEPL, (SleepTime & 0xFFFF));    
+      AD5940_WriteReg(REG_WUPTMR_SEQ0SLEEPH, (SleepTime & 0xF0000)>>16);
+      break;
+    }
+    case SEQID_1:
+    {
+      AD5940_WriteReg(REG_WUPTMR_SEQ1WUPL, (WakeupTime & 0xFFFF));    
+      AD5940_WriteReg(REG_WUPTMR_SEQ1WUPH, (WakeupTime & 0xF0000)>>16);
+      AD5940_WriteReg(REG_WUPTMR_SEQ1SLEEPL, (SleepTime & 0xFFFF));    
+      AD5940_WriteReg(REG_WUPTMR_SEQ1SLEEPH, (SleepTime & 0xF0000)>>16);
+      break;
+    }
+    case SEQID_2:
+    {
+      AD5940_WriteReg(REG_WUPTMR_SEQ2WUPL, (WakeupTime & 0xFFFF));    
+      AD5940_WriteReg(REG_WUPTMR_SEQ2WUPH, (WakeupTime & 0xF0000)>>16);
+      AD5940_WriteReg(REG_WUPTMR_SEQ2SLEEPL, (SleepTime & 0xFFFF));    
+      AD5940_WriteReg(REG_WUPTMR_SEQ2SLEEPH, (SleepTime & 0xF0000)>>16);
+      break;
+    }
+    case SEQID_3:
+    {
+      AD5940_WriteReg(REG_WUPTMR_SEQ3WUPL, (WakeupTime & 0xFFFF));    
+      AD5940_WriteReg(REG_WUPTMR_SEQ3WUPH, (WakeupTime & 0xF0000)>>16);
+      AD5940_WriteReg(REG_WUPTMR_SEQ3SLEEPL, (SleepTime & 0xFFFF));    
+      AD5940_WriteReg(REG_WUPTMR_SEQ3SLEEPH, (SleepTime & 0xF0000)>>16);
+      break;
+    }
+    default:
+    return AD5940ERR_PARA;
+  }
+  return AD5940ERR_OK;
+}
+
+/**
+ * @} end-of Sequencer_FIFO_Functions
+ * @} end-of Sequencer_FIFO
+*/
+
+/**
+ * @defgroup MISC_Block
+ * @brief Other functions not included in above blocks. Clock, GPIO, INTC etc.
+ * @{
+ *    @defgroup MISC_Block_Functions
+ *    @{
+*/
+
+/**
+ * @brief Configure AD5940 clock
+ * @param pClkCfg: Pointer to configuration structure.
+ * @return return none.
+*/
+void AD5940_CLKCfg(CLKCfg_Type *pClkCfg)
+{
+  uint32_t tempreg, reg_osccon;
+
+  reg_osccon = AD5940_ReadReg(REG_ALLON_OSCCON);
+  /* Enable clocks */
+  if(pClkCfg->HFXTALEn == bTRUE)
+  {
+    reg_osccon |= BITM_ALLON_OSCCON_HFXTALEN;
+    AD5940_WriteReg(REG_ALLON_OSCKEY,KEY_OSCCON); /* Write Key */
+    AD5940_WriteReg(REG_ALLON_OSCCON, reg_osccon); /* Enable HFXTAL */
+    while((AD5940_ReadReg(REG_ALLON_OSCCON)&BITM_ALLON_OSCCON_HFXTALOK) == 0); /* Wait for clock ready */
+  }
+
+  if(pClkCfg->HFOSCEn == bTRUE)
+  {
+    reg_osccon |= BITM_ALLON_OSCCON_HFOSCEN;
+    AD5940_WriteReg(REG_ALLON_OSCKEY,KEY_OSCCON); /* Write Key */
+    AD5940_WriteReg(REG_ALLON_OSCCON, reg_osccon); /* Enable HFOSC */
+    while((AD5940_ReadReg(REG_ALLON_OSCCON)&BITM_ALLON_OSCCON_HFOSCOK) == 0); /* Wait for clock ready */
+    /* Configure HFOSC mode if it's enabled. */
+    if(pClkCfg->HfOSC32MHzMode  == bTRUE)
+      AD5940_HFOSC32MHzCtrl(bTRUE);
+    else
+      AD5940_HFOSC32MHzCtrl(bFALSE);
+  }
+
+  if(pClkCfg->LFOSCEn == bTRUE)
+  {
+    reg_osccon |= BITM_ALLON_OSCCON_LFOSCEN;  
+    AD5940_WriteReg(REG_ALLON_OSCKEY,KEY_OSCCON); /* Write Key */  
+    AD5940_WriteReg(REG_ALLON_OSCCON, reg_osccon); /* Enable LFOSC */
+    while((AD5940_ReadReg(REG_ALLON_OSCCON)&BITM_ALLON_OSCCON_LFOSCOK) == 0); /* Wait for clock ready */
+  }
+
+  /* Switch clocks */
+  /* step1. Set clock divider */
+  tempreg = pClkCfg->SysClkDiv&0x3f;
+  tempreg |= (pClkCfg->SysClkDiv&0x3f) << BITP_AFECON_CLKCON0_SYSCLKDIV;
+  tempreg |= (pClkCfg->ADCClkDiv&0xf) << BITP_AFECON_CLKCON0_ADCCLKDIV;
+  AD5940_WriteReg(REG_AFECON_CLKCON0, tempreg);
+  AD5940_Delay10us(10);
+  /* Step2. set clock source */
+  tempreg = pClkCfg->SysClkSrc;
+  tempreg |= pClkCfg->ADCCLkSrc << BITP_AFECON_CLKSEL_ADCCLKSEL;
+  AD5940_WriteReg(REG_AFECON_CLKSEL, tempreg);
+
+  /* Disable clocks */
+  if(pClkCfg->HFXTALEn == bFALSE)
+    reg_osccon &= ~BITM_ALLON_OSCCON_HFXTALEN;
+  if(pClkCfg->HFOSCEn == bFALSE)
+    reg_osccon &= ~BITM_ALLON_OSCCON_HFOSCEN;
+  if(pClkCfg->LFOSCEn == bFALSE)
+    reg_osccon &= ~BITM_ALLON_OSCCON_LFOSCEN;
+  AD5940_WriteReg(REG_ALLON_OSCKEY, KEY_OSCCON); /* Write Key */
+  AD5940_WriteReg(REG_ALLON_OSCCON, reg_osccon);
+}
+
+/**
+ * @brief Configure Internal HFOSC to output 32MHz or 16MHz.
+ * @param Mode32MHz : {bTRUE, bFALSE}
+ *        - bTRUE: HFOSC 32MHz mode.
+ *        - bFALSE: HFOSC 16MHz mode.
+ * @return return none.
+*/
+void AD5940_HFOSC32MHzCtrl(BoolFlag Mode32MHz)
+{
+  uint32_t RdCLKEN1;
+  uint32_t RdHPOSCCON;   
+
+  uint32_t bit8,bit9;
+    
+  RdCLKEN1 = AD5940_ReadReg(REG_AFECON_CLKEN1);
+  bit8 = (RdCLKEN1>>9)&0x01;
+  bit9 = (RdCLKEN1>>8)&0x01;  /* Fix bug in silicon, bit8 and bit9 is swapped when read back. */
+  RdCLKEN1 = RdCLKEN1&0xff;
+  RdCLKEN1 |= (bit8<<8)|(bit9<<9);
+  AD5940_WriteReg(REG_AFECON_CLKEN1,RdCLKEN1|BITM_AFECON_CLKEN1_ACLKDIS); /* Disable ACLK during clock changing */
+
+  RdHPOSCCON = AD5940_ReadReg(REG_AFE_HPOSCCON); 
+  if(Mode32MHz == bTRUE)
+  {
+    AD5940_WriteReg(REG_AFE_HPOSCCON,RdHPOSCCON&(~BITM_AFE_HPOSCCON_CLK32MHZEN)); /* Enable 32MHz output(bit definition-0: 32MHz, 1: 16MHz) */  
+    while((AD5940_ReadReg(REG_ALLON_OSCCON)&BITM_ALLON_OSCCON_HFOSCOK) == 0); /* Wait for clock ready */
+  }
+  else
+  {
+    AD5940_WriteReg(REG_AFE_HPOSCCON,RdHPOSCCON|BITM_AFE_HPOSCCON_CLK32MHZEN); /* Enable 16MHz output(bit definition-0: 32MHz, 1: 16MHz) */       
+    while((AD5940_ReadReg(REG_ALLON_OSCCON)&BITM_ALLON_OSCCON_HFOSCOK) == 0); /* Wait for clock ready */
+  }
+
+  AD5940_WriteReg(REG_AFECON_CLKEN1,RdCLKEN1&(~BITM_AFECON_CLKEN1_ACLKDIS)); /* Enable ACLK */
+}
+/**
+ * @brief Enable high power mode for high frequency EIS
+ * @param Mode32MHz : {bTRUE, bFALSE}
+ *        - bTRUE: HFOSC 32MHz mode.
+ *        - bFALSE: HFOSC 16MHz mode.
+ * @return return none.
+*/
+void 			AD5940_HPModeEn(BoolFlag Enable)
+{
+	CLKCfg_Type clk_cfg;
+	uint32_t temp_reg = 0;
+	
+	/* Check what the system clock is */
+	temp_reg = AD5940_ReadReg(REG_AFECON_CLKSEL);
+	clk_cfg.ADCCLkSrc = (temp_reg>>2)&0x3; 
+  clk_cfg.SysClkSrc = temp_reg & 0x3; 
+	if(Enable == bTRUE)
+	{
+		clk_cfg.SysClkDiv = SYSCLKDIV_2;
+		clk_cfg.HfOSC32MHzMode = bTRUE;
+		AD5940_AFEPwrBW(AFEPWR_HP, AFEBW_250KHZ);
+	}
+	else
+	{
+		clk_cfg.SysClkDiv = SYSCLKDIV_1;
+		clk_cfg.HfOSC32MHzMode = bFALSE;
+		AD5940_AFEPwrBW(AFEPWR_LP, AFEBW_100KHZ);
+	}
+    clk_cfg.ADCClkDiv = ADCCLKDIV_1;       
+    clk_cfg.HFOSCEn = (temp_reg & 0x3) == 0x1? bFALSE : bTRUE;;
+	clk_cfg.HFXTALEn = (temp_reg & 0x3) == 0x1? bTRUE : bFALSE;
+    clk_cfg.LFOSCEn = bTRUE;
+    AD5940_CLKCfg(&clk_cfg);
+}
+
+/**
+ * @defgroup Interrupt_Controller_Functions
+ * @{
+*/
+/* AFE Interrupt Controller */
+/**
+ * @brief Enable or Disable selected interrupt source(s)
+ * @param AfeIntcSel : {AFEINTC_0, AFEINTC_1}
+ *        - AFEINTC_0: Configure Interrupt Controller 0
+ *        - AFEINTC_1: Configure Interrupt Controller 1
+ * @param AFEIntSrc: select from @ref AFEINTC_SRC_Const
+ *       - AFEINTSRC_ADCRDY        : Bit0 ADC Result Ready Status
+ *       - AFEINTSRC_DFTRDY        : Bit1 DFT Result Ready Status
+ *       - AFEINTSRC_SUPPLYFILTRDY : Bit2 Low Pass Filter Result Status
+ *       - AFEINTSRC_TEMPRDY       : Bit3, Temp Sensor Result Ready
+ *       - AFEINTSRC_ADCMINERR     : Bit4, ADC Minimum Value
+ *       - AFEINTSRC_ADCMAXERR     : Bit5, ADC Maximum Value
+ *       - AFEINTSRC_ADCDIFFERR    : Bit6, ADC Delta Ready
+ *       - AFEINTSRC_MEANRDY       : Bit7, Mean Result Ready
+ *       - AFEINTSRC_VARRDY       : Bit8, Variance Result Ready 
+ *       - AFEINTSRC_DLYCMDDONE   : Bit9, User controlled interrupt by writing AFEGENINTSTA. Provides an Early Indication for the End of the Test _Block.
+ *       - AFEINTSRC_HWSETUPDONE  : Bit10, User controlled interrupt by writing AFEGENINTSTA. Indicates the MMR Setup for the Measurement Step Finished 
+ *       - AFEINTSRC_BRKSEQ       : Bit11, User controlled interrupt by writing AFEGENINTSTA.
+ *       - AFEINTSRC_CUSTOMINS    : Bit12, User controlled interrupt by writing AFEGENINTSTA. General Purpose Custom Interrupt. 
+ *       - AFEINTSRC_BOOTLDDONE   : Bit13, OTP Boot Loading Done 
+ *       - AFEINTSRC_WAKEUP       : Bit14, AFE Woken up
+ *       - AFEINTSRC_ENDSEQ       : Bit15, End of Sequence Interrupt. 
+ *       - AFEINTSRC_SEQTIMEOUT   : Bit16, Sequencer Timeout Command Finished. 
+ *       - AFEINTSRC_SEQTIMEOUTERR : Bit17, Sequencer Timeout Command Error. 
+ *       - AFEINTSRC_CMDFIFOFULL  : Bit18, Command FIFO Full Interrupt. 
+ *       - AFEINTSRC_CMDFIFOEMPTY : Bit19, Command FIFO Empty 
+ *       - AFEINTSRC_CMDFIFOTHRESH: Bit20, Command FIFO Threshold Interrupt. 
+ *       - AFEINTSRC_CMDFIFOOF    : Bit21, Command FIFO Overflow Interrupt. 
+ *       - AFEINTSRC_CMDFIFOUF    : Bit22, Command FIFO Underflow Interrupt. 
+ *       - AFEINTSRC_DATAFIFOFULL : Bit23, Data FIFO Full Interrupt. 
+ *       - AFEINTSRC_DATAFIFOEMPTY: Bit24, Data FIFO Empty 
+ *       - AFEINTSRC_DATAFIFOTHRESH: Bit25, Data FIFO Threshold Interrupt. 
+ *       - AFEINTSRC_DATAFIFOOF   : Bit26, Data FIFO Overflow Interrupt. 
+ *       - AFEINTSRC_DATAFIFOUF   : Bit27, Data FIFO Underflow Interrupt. 
+ *       - AFEINTSRC_WDTIRQ       : Bit28, WDT Timeout Interrupt. 
+ *       - AFEINTSRC_CRC_OUTLIER  : Bit29, CRC interrupt for M355, Outliers Int for AD5940  
+ *       - AFEINTSRC_GPT0INT_SLPWUT: Bit30, General Purpose Timer0 IRQ for M355. Sleep or Wakeup Timer timeout for AD5940
+ *       - AFEINTSRC_GPT1INT_TRYBRK: Bit31, General Purpose Timer1 IRQ for M355. Tried to Break IRQ for AD5940
+ *       - AFE_INTC_ALLINT        : All interrupts
+ * @param State : {bTRUE, bFALSE}
+ *      - bTRUE: Enable these interrupt source(s)
+ *      - bFALSE: Disable interrupt source(s)
+ * @return return none.
+*/
+void AD5940_INTCCfg(uint32_t AfeIntcSel, uint32_t AFEIntSrc, BoolFlag State)
+{
+  uint32_t tempreg;
+  uint32_t regaddr = REG_INTC_INTCSEL0;
+  
+  if(AfeIntcSel == AFEINTC_1)
+    regaddr = REG_INTC_INTCSEL1;
+  
+  tempreg = AD5940_ReadReg(regaddr);
+  if(State == bTRUE)
+    tempreg |= AFEIntSrc;    /* Enable this interrupt */
+  else
+    tempreg &= ~(AFEIntSrc); /* Disable this interrupt  */
+  AD5940_WriteReg(regaddr,tempreg);
+}
+
+/**
+ * @brief Check if current interrupt configuration.
+ * @param AfeIntcSel : {AFEINTC_0, AFEINTC_1}
+ *        - AFEINTC_0: Configure Interrupt Controller 0
+ *        - AFEINTC_1: Configure Interrupt Controller 1
+*/
+uint32_t AD5940_INTCGetCfg(uint32_t AfeIntcSel)
+{
+  uint32_t tempreg;
+  if(AfeIntcSel == AFEINTC_0)
+    tempreg = AD5940_ReadReg(REG_INTC_INTCSEL0);
+  else
+    tempreg = AD5940_ReadReg(REG_INTC_INTCSEL1);
+  return tempreg;
+}
+
+/**
+ * @brief Clear selected interrupt(s) flag(INTC0Flag and INTC1Flag are both cleared).
+ * @param AfeIntSrcSel: Select from @ref AFEINTC_SRC_Const
+ * @return return none.
+**/
+void AD5940_INTCClrFlag(uint32_t AfeIntSrcSel)
+{
+  AD5940_WriteReg(REG_INTC_INTCCLR,AfeIntSrcSel);
+}
+
+/**
+ * @brief Test if selected interrupt source(s) is(are) bTRUE.
+ * @param AfeIntcSel : {AFEINTC_0, AFEINTC_1}
+ *        - AFEINTC_0: Read Interrupt Controller 0 flag
+ *        - AFEINTC_1: Read Interrupt Controller 1 flag
+ * @param AfeIntSrcSel: Select from @ref AFEINTC_SRC_Const
+ * @return If selected interrupt source(s) are all cleared, return bFALSE. Otherwise return bTRUE.
+**/
+BoolFlag AD5940_INTCTestFlag(uint32_t AfeIntcSel, uint32_t AfeIntSrcSel)
+{
+  uint32_t tempreg;
+  uint32_t regaddr = (AfeIntcSel == AFEINTC_0)? REG_INTC_INTCFLAG0: REG_INTC_INTCFLAG1;
+  
+  tempreg = AD5940_ReadReg(regaddr);
+  if(tempreg & AfeIntSrcSel)
+    return bTRUE;
+  else
+    return bFALSE;
+}
+
+/**
+ * @brief return register value of REG_INTC_INTCFLAGx
+ * @param AfeIntcSel : {AFEINTC_0, AFEINTC_1}
+ *        - AFEINTC_0: Read Interrupt Controller 0 flag
+ *        - AFEINTC_1: Read Interrupt Controller 1 flag     
+ * @return register value of REG_INTC_INTCFLAGx.
+**/
+uint32_t AD5940_INTCGetFlag(uint32_t AfeIntcSel)
+{
+  uint32_t tempreg;
+  uint32_t regaddr = (AfeIntcSel == AFEINTC_0)? REG_INTC_INTCFLAG0: REG_INTC_INTCFLAG1;
+  
+  tempreg = AD5940_ReadReg(regaddr);
+  return tempreg;
+}
+
+/**
+ * @} Interrupt_Controller_Functions
+*/
+
+/**
+ * @defgroup GPIO_Block_Functions
+ * @{
+*/
+
+/**
+ * @brief Initialize AFE GPIO
+ * @param pAgpioCfg: Pointer to configuration structure
+ * @return return none.
+*/
+void AD5940_AGPIOCfg(AGPIOCfg_Type *pAgpioCfg)
+{
+  AD5940_AGPIOFuncCfg(pAgpioCfg->FuncSet);
+  AD5940_AGPIOOen(pAgpioCfg->OutputEnSet);
+  AD5940_AGPIOIen(pAgpioCfg->InputEnSet);
+  AD5940_AGPIOPen(pAgpioCfg->PullEnSet);
+  AD5940_WriteReg(REG_AGPIO_GP0OUT, pAgpioCfg->OutVal);
+}
+
+/**
+ * @brief Configure the function of GP0 to GP7.
+ * @param uiCfgSet :{GP0_INT,GP0_TRIG,GP0_SYNC,GP0_GPIO|
+ *               GP1_GPIO,GP1_TRIG,GP1_SYNC,GP1_SLEEP|
+ *                GP2_PORB,GP2_TRIG,GP2_SYNC,GP2_EXTCLK|
+ *                GP3_GPIO,GP3_TRIG,GP3_SYNC,GP3_INT0|\
+ *                GP4_GPIO,GP4_TRIG,GP4_SYNC,GP4_INT1|
+ *                GP5_GPIO,GP5_TRIG,GP5_SYNC,GP5_EXTCLK|
+ *                GP6_GPIO,GP6_TRIG,GP6_SYNC,GP6_INT0|
+ *                GP7_GPIO,GP7_TRIG,GP7_SYNC,GP7_INT}
+ * @return return none.
+**/
+void AD5940_AGPIOFuncCfg(uint32_t uiCfgSet)
+{
+   AD5940_WriteReg(REG_AGPIO_GP0CON,uiCfgSet);
+}
+
+/**
+ * @brief Enable GPIO output mode on selected pins. Disable output on non-selected pins.
+ * @param uiPinSet :Select from {AGPIO_Pin0|AGPIO_Pin1|AGPIO_Pin2|AGPIO_Pin3|AGPIO_Pin4|AGPIO_Pin5|AGPIO_Pin6|AGPIO_Pin7}
+ * @return return none
+**/
+void AD5940_AGPIOOen(uint32_t uiPinSet)
+{
+   AD5940_WriteReg(REG_AGPIO_GP0OEN,uiPinSet);
+}
+
+/**
+ * @brief Enable input on selected pins while disable others.
+ * @param uiPinSet: Select from {AGPIO_Pin0|AGPIO_Pin1|AGPIO_Pin2|AGPIO_Pin3|AGPIO_Pin4|AGPIO_Pin5|AGPIO_Pin6|AGPIO_Pin7}
+ * @return return none
+**/
+void AD5940_AGPIOIen(uint32_t uiPinSet)
+{
+   AD5940_WriteReg(REG_AGPIO_GP0IEN,uiPinSet);
+}
+
+/**
+ * @brief Read the GPIO status.
+ * @return return GP0IN register which is the GPIO status.
+**/
+uint32_t AD5940_AGPIOIn(void)
+{
+  return AD5940_ReadReg(REG_AGPIO_GP0IN);
+}
+
+/**
+ * @brief Enable pull-up or down on selected pins while disable other pins.
+ * @param uiPinSet: Select from: {AGPIO_Pin0|AGPIO_Pin1|AGPIO_Pin2|AGPIO_Pin3|AGPIO_Pin4|AGPIO_Pin5|AGPIO_Pin6|AGPIO_Pin7}
+ * @return return none
+**/
+void AD5940_AGPIOPen(uint32_t uiPinSet)
+{
+   AD5940_WriteReg(REG_AGPIO_GP0PE,uiPinSet);
+}
+
+/**
+ * @brief Put selected GPIOs to high level.
+ * @param uiPinSet: Select from: {AGPIO_Pin0|AGPIO_Pin1|AGPIO_Pin2|AGPIO_Pin3|AGPIO_Pin4|AGPIO_Pin5|AGPIO_Pin6|AGPIO_Pin7}
+ * @return return none
+**/
+void AD5940_AGPIOSet(uint32_t uiPinSet)
+{
+   AD5940_WriteReg(REG_AGPIO_GP0SET,uiPinSet);
+}
+
+/**
+ * @brief Put selected GPIOs to low level.
+ * @param uiPinSet: Select from: {AGPIO_Pin0|AGPIO_Pin1|AGPIO_Pin2|AGPIO_Pin3|AGPIO_Pin4|AGPIO_Pin5|AGPIO_Pin6|AGPIO_Pin7}
+ * @return return none
+**/
+void AD5940_AGPIOClr(uint32_t uiPinSet)
+{
+   AD5940_WriteReg(REG_AGPIO_GP0CLR,uiPinSet);
+}
+
+/**
+ * @brief Toggle selected GPIOs.
+ * @param uiPinSet: Select from: {AGPIO_Pin0|AGPIO_Pin1|AGPIO_Pin2|AGPIO_Pin3|AGPIO_Pin4|AGPIO_Pin5|AGPIO_Pin6|AGPIO_Pin7}
+ * @return return none
+**/
+void AD5940_AGPIOToggle(uint32_t uiPinSet)
+{
+   AD5940_WriteReg(REG_AGPIO_GP0TGL,uiPinSet);
+}
+
+/**
+ * @} GPIO_Block_Functions
+*/
+
+/**
+ * @defgroup LPMode_Block_Functions
+ * @{
+*/
+/**
+ * @brief Enter or leave LPMODE. 
+ * @details Once enter this mode, some registers are collected together to a new register so we can
+ *          Control most blocks with in one register. The so called LPMODE has nothing to do with AD5940 power.
+ * @return return AD5940ERR_OK
+**/
+AD5940Err AD5940_LPModeEnS(BoolFlag LPModeEn)
+{
+  if(LPModeEn == bTRUE)
+    AD5940_WriteReg(REG_AFE_LPMODEKEY, KEY_LPMODEKEY);  /* Enter LP mode by right key. */
+  else
+    AD5940_WriteReg(REG_AFE_LPMODEKEY, 0); /* Write wrong key to exit LP mode */
+  return AD5940ERR_OK;
+}
+
+/**
+ * @brief Select system clock source for LPMODE. 
+ * @note Only in LP Mode, this operation takes effect. Enter LPMODE by function @ref AD5940_LPModeEnS.
+ * @param LPModeClk: Select from @ref LPMODECLK_Const
+ *       - LPMODECLK_LFOSC: Select LFOSC 32kHz for system clock
+ *       - LPMODECLK_HFOSC: Select HFOSC 16MHz/32MHz for system clock
+ * @return none.
+*/
+void AD5940_LPModeClkS(uint32_t LPModeClk)
+{
+  AD5940_WriteReg(REG_AFE_LPMODECLKSEL, LPModeClk);
+}
+
+/**
+ * @} LPMode_Block_Functions
+*/
+
+/**
+ * @brief Enter sleep mode key to unlock it or enter incorrect key to lock it. \
+ *        Once key is unlocked, it will always be effect until manually lock it
+ * @param SlpKey : {SLPKEY_UNLOCK, SLPKEY_LOCK}
+          - SLPKEY_UNLOCK Unlock Key so we can enter sleep(or called hibernate) mode.
+          - SLPKEY_LOCK Lock key so AD5940 is prohibited to enter sleep mode.
+   @return return none.
+*/
+void AD5940_SleepKeyCtrlS(uint32_t SlpKey)
+{
+  AD5940_WriteReg(REG_AFE_SEQSLPLOCK, SlpKey);
+}
+
+/**
+ * @brief Put AFE to hibernate. 
+ * @details This will only take effect when SLP_KEY has been unlocked. Use function @ref AD5940_SleepKeyCtrlS to enter correct key.
+ * @return return none.
+*/
+void AD5940_EnterSleepS(void)
+{
+  AD5940_WriteReg(REG_AFE_SEQTRGSLP, 0);
+  AD5940_WriteReg(REG_AFE_SEQTRGSLP, 1);
+}
+
+/**
+ * @brief Turn off LP-Loop and put AFE to hibernate mode;
+ * @details By function @ref AD5940_EnterSleepS, we can put most blocks to hibernate mode except LP block.
+ *          This function will shut down LP block and then enter sleep mode.
+ * @return return none.
+*/
+void AD5940_ShutDownS(void)
+{
+  /* Turn off LPloop related blocks which are not controlled automatically by hibernate operation */
+  AFERefCfg_Type aferef_cfg;
+  LPLoopCfg_Type lp_loop;
+  /* Turn off LP-loop manually because it's not affected by sleep/hibernate mode */
+  AD5940_StructInit(&aferef_cfg, sizeof(aferef_cfg));
+  AD5940_StructInit(&lp_loop, sizeof(lp_loop));
+  AD5940_REFCfgS(&aferef_cfg);
+  AD5940_LPLoopCfgS(&lp_loop);
+  AD5940_SleepKeyCtrlS(SLPKEY_UNLOCK);  /* Unlock the key */
+  AD5940_EnterSleepS();  /* Enter Hibernate */
+}
+
+/**
+ * @brief Try to wakeup AD5940 by read register.
+ * @details Any SPI operation can wakeup AD5940. AD5940_Initialize must be called to enable this function.
+ * @param TryCount Specify how many times we will read register. Zero or negative number means always waiting here.
+ * @return How many times register is read. If returned value is bigger than TryCount, it means wakeup failed.
+*/
+uint32_t  AD5940_WakeUp(int32_t TryCount)
+{
+  uint32_t count = 0;
+  while(1)
+  {
+    count++;
+    if(AD5940_ReadReg(REG_AFECON_ADIID) == AD5940_ADIID)
+      break;    /* Succeed */
+    if(TryCount<=0) 
+      continue; /* Always try to wakeup AFE */
+
+    if(count > TryCount)
+      break;    /* Failed */
+  }
+  return count;
+}
+
+/**
+ * @brief Read ADIID register, the value for current version is @ref AD5940_ADIID
+ * @return return none.
+*/
+uint32_t AD5940_GetADIID(void)
+{
+  return AD5940_ReadReg(REG_AFECON_ADIID);
+}
+
+/**
+ * @brief Read CHIPID register, the value for current version is 0x5501.
+ * @return return none.
+*/
+uint32_t AD5940_GetChipID(void)
+{
+  return AD5940_ReadReg(REG_AFECON_CHIPID);
+}
+/**
+ * @brief Reset AD5940 by register.
+ * @note AD5940 must be in active state so we can access registers.
+ *       If AD5940 system clock is too low, we consider to use hardware reset, or 
+ *       we need to make sure register write is successfully.
+ * @return return none.
+*/
+AD5940Err  AD5940_SoftRst(void)
+{
+  AD5940_WriteReg(REG_AFECON_SWRSTCON, AD5940_SWRST);
+  AD5940_Delay10us(20); /* AD5940 need some time to exit reset status. 200us looks good. */
+  /* We can check RSTSTA register to make sure software reset happened. */
+  return AD5940ERR_OK;
+}
+
+/**
+ * @brief Reset AD5940 with RESET pin.
+ * @note This will call function AD5940_RstClr which locates in file XXXPort.C
+ * @return return none.
+*/
+void AD5940_HWReset(void)
+{
+#ifndef CHIPSEL_M355
+  AD5940_RstClr();
+  AD5940_Delay10us(200); /* Delay some time */
+  AD5940_RstSet();
+  AD5940_Delay10us(500); /* AD5940 need some time to exit reset status. 200us looks good. */
+#else
+  //There is no method to reset AFE only for M355.
+#endif
+}
+
+/**
+ * @} MISC_Block_Functions
+ * @} MISC_Block
+*/
+
+/**
+ * @defgroup Calibration_Block
+ * @brief The non-factory calibration routines.
+ * @{
+ *    @defgroup Calibration_Functions
+ *    @{
+ *  
+ * 
+ */
+/**
+ * @brief Turn on High power 1.8V/1.1V reference and 2.5V LP reference.
+ * @return return none.
+*/
+static void __AD5940_ReferenceON(void)
+{
+  AFERefCfg_Type ref_cfg;
+  /* Turn ON ADC/DAC and LPDAC reference */
+  ref_cfg.Hp1V1BuffEn = bTRUE;
+  ref_cfg.Hp1V8BuffEn = bTRUE;
+  ref_cfg.HpBandgapEn = bTRUE;
+  ref_cfg.HSDACRefEn = bTRUE;
+  ref_cfg.LpBandgapEn = bTRUE;
+  ref_cfg.LpRefBufEn = bTRUE;
+
+  ref_cfg.Disc1V1Cap = bFALSE;
+  ref_cfg.Disc1V8Cap = bFALSE;
+  ref_cfg.Hp1V8Ilimit = bFALSE;
+  ref_cfg.Hp1V8ThemBuff = bFALSE;
+  ref_cfg.Lp1V1BuffEn = bFALSE;
+  ref_cfg.Lp1V8BuffEn = bFALSE;
+  ref_cfg.LpRefBoostEn = bFALSE;
+  AD5940_REFCfgS(&ref_cfg);
+}
+
+/**
+ * @brief Turn on ADC to sample one SINC2 data.
+ * @return return ADCCode.
+*/
+static uint32_t __AD5940_TakeMeasurement(int32_t *time_out)
+{
+  uint32_t ADCCode = 0;
+  AD5940_INTCClrFlag(AFEINTSRC_SINC2RDY);
+  AD5940_AFECtrlS(AFECTRL_ADCCNV|AFECTRL_SINC2NOTCH, bTRUE);/* Start conversion */
+  do
+  {
+    AD5940_Delay10us(1);  /* Delay 10us */
+    if(AD5940_INTCTestFlag(AFEINTC_1,AFEINTSRC_SINC2RDY))
+    {
+        ADCCode = AD5940_ReadAfeResult(AFERESULT_SINC2);
+        break;
+    }
+    if(*time_out != -1)
+      (*time_out)--;	
+  }while(*time_out != 0);
+  AD5940_AFECtrlS(AFECTRL_ADCCNV|AFECTRL_SINC2NOTCH, bFALSE);/* Stop conversion */
+  return ADCCode;
+}
+
+/**
+  @brief Calibrate ADC PGA
+  @param pADCPGACal: PGA calibration parameters include filter setup and PGA gain.
+  @return AD5940ERR_OK.
+**/
+AD5940Err AD5940_ADCPGACal(ADCPGACal_Type *pADCPGACal)
+{
+  const float kFactor = 1.835f/1.82f;
+  ADCBaseCfg_Type adc_base;
+
+  int32_t time_out;
+  uint32_t INTCCfg;
+  int32_t ADCCode;
+  BoolFlag bADCClk32MHzMode;
+
+  uint32_t regaddr_gain, regaddr_offset;
+  
+  if(pADCPGACal == NULL) return AD5940ERR_NULLP;
+  if(pADCPGACal->ADCPga > ADCPGA_9) return AD5940ERR_PARA;  /* Parameter Error */
+  
+  if(pADCPGACal->AdcClkFreq > (32000000*0.8))
+    bADCClk32MHzMode = bTRUE; 
+
+  /**
+   *  Determine Gain calibration method according to different gain value...
+   *  and calibration register 
+   * */
+  static const struct _cal_registers
+  {
+    uint16_t gain_reg;
+    uint16_t offset_reg;
+  }cal_registers[] = {
+    {REG_AFE_ADCGAINGN1,REG_AFE_ADCOFFSETGN1},
+    {REG_AFE_ADCGAINGN1P5,REG_AFE_ADCOFFSETGN1P5},
+    {REG_AFE_ADCGAINGN2,REG_AFE_ADCOFFSETGN2},
+    {REG_AFE_ADCGAINGN4,REG_AFE_ADCOFFSETGN4},
+    {REG_AFE_ADCGAINGN9,REG_AFE_ADCOFFSETGN9},
+  };
+  regaddr_gain = cal_registers[pADCPGACal->ADCPga].gain_reg;
+  regaddr_offset = cal_registers[pADCPGACal->ADCPga].offset_reg;
+
+  /* Do initialization */
+  __AD5940_ReferenceON();
+  ADCFilterCfg_Type adc_filter;
+  /* Initialize ADC filters ADCRawData-->SINC3-->SINC2+NOTCH. Use SIN2 data for calibration-->Lower noise */
+  adc_filter.ADCSinc3Osr = pADCPGACal->ADCSinc3Osr;
+  adc_filter.ADCSinc2Osr = pADCPGACal->ADCSinc2Osr;  /* 800KSPS/4/1333 = 150SPS */
+  adc_filter.ADCAvgNum = ADCAVGNUM_2;         /* Don't care about it. Average function is only used for DFT */
+  adc_filter.ADCRate = bADCClk32MHzMode?ADCRATE_1P6MHZ:ADCRATE_800KHZ;        /* If ADC clock is 32MHz, then set it to ADCRATE_1P6MHZ. Default is 16MHz, use ADCRATE_800KHZ. */
+  adc_filter.BpNotch = bTRUE;                 /* SINC2+Notch is one block, when bypass notch filter, we can get fresh data from SINC2 filter. */
+  adc_filter.BpSinc3 = bFALSE;                /* We use SINC3 filter. */
+  adc_filter.Sinc2NotchEnable = bTRUE;        /* Enable the SINC2+Notch block. You can also use function AD5940_AFECtrlS */
+  AD5940_ADCFilterCfgS(&adc_filter);
+  /* Turn ON reference and ADC power, and DAC reference. We use DAC 1.8V reference to calibrate ADC because of the ADC reference bug. */
+  AD5940_AFECtrlS(AFECTRL_ALL, bFALSE); /* Disable all */
+  AD5940_AFECtrlS(AFECTRL_ADCPWR|AFECTRL_HPREFPWR|AFECTRL_DACREFPWR|AFECTRL_HSDACPWR|AFECTRL_SINC2NOTCH, bTRUE);
+  AD5940_Delay10us(25);   /* Wait 250us for reference power up */
+  /* INTC configure and open calibration lock */
+  INTCCfg = AD5940_INTCGetCfg(AFEINTC_1);
+  AD5940_INTCCfg(AFEINTC_1, AFEINTSRC_SINC2RDY, bTRUE); /* Enable SINC2 Interrupt in INTC1 */
+  AD5940_WriteReg(REG_AFE_CALDATLOCK, KEY_CALDATLOCK);  /* Unlock KEY */
+
+  /* Do offset calibration. */
+  if(pADCPGACal->PGACalType != PGACALTYPE_GAIN){  /* Need offset calibration */
+    int32_t ExpectedCode = 0x8000;        /* Ideal ADC output */
+    AD5940_WriteReg(regaddr_offset, 0);   /* Reset offset register */
+
+    adc_base.ADCMuxP = ADCMUXP_VSET1P1;
+    adc_base.ADCMuxN = ADCMUXN_VSET1P1;   /* Short input with common voltage set to 1.11v */
+    adc_base.ADCPga = pADCPGACal->ADCPga; /* Set correct Gain value. */
+    AD5940_ADCBaseCfgS(&adc_base);
+    AD5940_Delay10us(5);                  /* Wait for sometime */
+    ADCCode = 0;
+    for(int i=0; i<8; i++)
+    { /* ADC offset calibration register has resolution of 0.25LSB. take full use of it. */
+      time_out = pADCPGACal->TimeOut10us;   /* Reset time out counter */
+      ADCCode += __AD5940_TakeMeasurement(&time_out);  /* Turn on ADC to get one valid data and then turn off ADC. */
+      if(time_out == 0) goto ADCPGACALERROR_TIMEOUT;  /* Time out error. */
+    }
+    /* Calculate and write the result to registers before gain calibration */
+    ADCCode = (ExpectedCode<<3) - ADCCode;  /* We will shift back 1bit below */
+    /**
+     * AD5940 use formular Output = gain*(input + offset) for calibration.
+     * So, the measured results should be divided by gain to get value for offset register.
+    */
+    uint32_t gain = AD5940_ReadReg(regaddr_gain);
+    ADCCode = (ADCCode*0x4000)/gain;
+    ADCCode = ((ADCCode+1)>>1)&0x7fff;      /* Round 0.5 */
+    AD5940_WriteReg(regaddr_offset, ADCCode);
+  }
+  
+  /* Do gain calibration */
+  if(pADCPGACal->PGACalType != PGACALTYPE_OFFSET)  /* Need gain calibration */
+  {
+    int32_t ExpectedGainCode;
+    static const float ideal_pga_gain[]={1,1.5,2,4,9};
+    AD5940_WriteReg(regaddr_gain, 0x4000);  /* Reset gain register */
+    if(pADCPGACal->ADCPga <= ADCPGA_2)
+    {
+      //gain1,1.5,2 could use reference directly
+      adc_base.ADCMuxP = ADCMUXP_VREF1P8DAC;
+      adc_base.ADCMuxN = ADCMUXN_VSET1P1;
+      ExpectedGainCode = (int32_t)((pADCPGACal->VRef1p82 - pADCPGACal->VRef1p11)*ideal_pga_gain[pADCPGACal->ADCPga]/\
+                                    pADCPGACal->VRef1p82*32768/kFactor)\
+                                    + 0x8000;
+    }
+    else
+    {
+      //gain4,9 use DAC generated voltage
+      adc_base.ADCMuxP = ADCMUXP_P_NODE;
+      adc_base.ADCMuxN = ADCMUXN_N_NODE;
+      /* Setup HSLOOP to generate voltage for GAIN4/9 calibration. */
+      AD5940_AFECtrlS(AFECTRL_EXTBUFPWR|AFECTRL_INAMPPWR|AFECTRL_HSTIAPWR|AFECTRL_WG, bTRUE);
+      HSLoopCfg_Type hsloop_cfg;
+      hsloop_cfg.HsDacCfg.ExcitBufGain = EXCITBUFGAIN_2;
+      hsloop_cfg.HsDacCfg.HsDacGain = HSDACGAIN_1;
+      hsloop_cfg.HsDacCfg.HsDacUpdateRate = 7;
+      hsloop_cfg.HsTiaCfg.DiodeClose = bFALSE;
+      hsloop_cfg.HsTiaCfg.HstiaBias = HSTIABIAS_1P1;
+      hsloop_cfg.HsTiaCfg.HstiaCtia = 31;
+      hsloop_cfg.HsTiaCfg.HstiaDeRload = HSTIADERLOAD_OPEN;
+      hsloop_cfg.HsTiaCfg.HstiaDeRtia = HSTIADERTIA_OPEN;
+      hsloop_cfg.HsTiaCfg.HstiaDe1Rload = HSTIADERLOAD_OPEN;
+      hsloop_cfg.HsTiaCfg.HstiaDe1Rtia = HSTIADERTIA_OPEN;
+      hsloop_cfg.HsTiaCfg.HstiaRtiaSel = HSTIARTIA_200;
+      hsloop_cfg.SWMatCfg.Dswitch = SWD_OPEN;
+      hsloop_cfg.SWMatCfg.Pswitch = SWP_PL;
+      hsloop_cfg.SWMatCfg.Nswitch = SWN_NL;
+      hsloop_cfg.SWMatCfg.Tswitch = SWT_TRTIA;
+      hsloop_cfg.WgCfg.GainCalEn = bTRUE;
+      hsloop_cfg.WgCfg.OffsetCalEn = bTRUE;
+      hsloop_cfg.WgCfg.WgType = WGTYPE_MMR;
+      uint32_t HSDACCode;
+      if(pADCPGACal->ADCPga == ADCPGA_4)
+        HSDACCode = 0x800 + 0x300;  /* 0x300--> 0x300/0x1000*0.8*BUFFERGAIN2 = 0.3V. */
+      else if(pADCPGACal->ADCPga == ADCPGA_9)
+        HSDACCode = 0x800 + 0x155;  /* 0x155--> 0x155/0x1000*0.8*BUFFERGAIN2 = 0.133V. */
+      hsloop_cfg.WgCfg.WgCode = HSDACCode;
+      AD5940_HSLoopCfgS(&hsloop_cfg);
+
+      //measure expected code
+      adc_base.ADCPga = ADCPGA_1P5;
+      AD5940_ADCBaseCfgS(&adc_base);  
+      AD5940_Delay10us(5);
+      time_out = pADCPGACal->TimeOut10us;   /* Reset time out counter */
+      ExpectedGainCode = 0x8000 + (int32_t)((__AD5940_TakeMeasurement(&time_out) - 0x8000)/1.5f\
+                                            *ideal_pga_gain[pADCPGACal->ADCPga]);
+      if(time_out == 0) goto ADCPGACALERROR_TIMEOUT;
+    }
+    adc_base.ADCPga = pADCPGACal->ADCPga;    /* Set to gain under calibration */
+    AD5940_ADCBaseCfgS(&adc_base);
+    AD5940_Delay10us(5);
+    time_out = pADCPGACal->TimeOut10us;      /* Reset time out counter */
+    ADCCode = __AD5940_TakeMeasurement(&time_out);
+    if(time_out == 0) goto ADCPGACALERROR_TIMEOUT;
+    /* Calculate and write the result to registers */
+    ADCCode = (ExpectedGainCode - 0x8000)*0x4000/(ADCCode-0x8000);
+    ADCCode &= 0x7fff;
+    AD5940_WriteReg(regaddr_gain, ADCCode);
+  }
+
+  /* Restore INTC1 SINC2 configure */
+  if(INTCCfg&AFEINTSRC_SINC2RDY);
+  else
+    AD5940_INTCCfg(AFEINTC_1, AFEINTSRC_SINC2RDY, bFALSE); /* Disable SINC2 Interrupt */
+
+  AD5940_WriteReg(REG_AFE_CALDATLOCK, 0);  /* Lock KEY */
+  /* Done */
+  return AD5940ERR_OK;
+
+ADCPGACALERROR_TIMEOUT:
+  AD5940_ADCConvtCtrlS(bFALSE);  /* Stop conversion */
+  AD5940_WriteReg(REG_AFE_CALDATLOCK, 0);  /* Lock KEY */
+  return AD5940ERR_TIMEOUT;
+}
+
+/**
+ * @brief Calibrate LPTIA offset
+ * @param pLPTIAOffsetCal Pointer to LPTIA offset calibration settings.
+ * @return AD5940ERR_OK.
+**/
+AD5940Err AD5940_LPTIAOffsetCal(LPTIAOffsetCal_Type *pLPTIAOffsetCal)
+{
+  AD5940Err error = AD5940ERR_OK;
+  LPLoopCfg_Type lploop_cfg;
+  ADCBaseCfg_Type adc_base;
+  ADCFilterCfg_Type adc_filter;
+
+  int32_t time_out;
+  uint32_t INTCCfg;
+  int32_t ADCCode;
+  BoolFlag bADCClk32MHzMode;
+  
+  if(pLPTIAOffsetCal == NULL) return AD5940ERR_NULLP;  
+  if(pLPTIAOffsetCal->AdcClkFreq > (32000000*0.8))
+    bADCClk32MHzMode = bTRUE;
+
+  /* Step0: Do initialization */
+  /* Turn on AD5940 references in case it's disabled. */
+  __AD5940_ReferenceON();
+  lploop_cfg.LpAmpCfg.LpAmpSel = pLPTIAOffsetCal->LpAmpSel;
+  lploop_cfg.LpAmpCfg.LpAmpPwrMod = pLPTIAOffsetCal->LpAmpPwrMod;  /* Power mode will affect amp offset. */
+  lploop_cfg.LpAmpCfg.LpPaPwrEn = bTRUE;
+  lploop_cfg.LpAmpCfg.LpTiaPwrEn = bTRUE;
+  lploop_cfg.LpAmpCfg.LpTiaRf = LPTIARF_OPEN;
+  lploop_cfg.LpAmpCfg.LpTiaRload = LPTIARLOAD_100R;
+  lploop_cfg.LpAmpCfg.LpTiaRtia = pLPTIAOffsetCal->LpTiaRtia;
+  lploop_cfg.LpAmpCfg.LpTiaSW = pLPTIAOffsetCal->LpTiaSW;  /* Disconnect capacitors so it settles quickly */
+  lploop_cfg.LpDacCfg.LpdacSel = (pLPTIAOffsetCal->LpAmpSel == LPAMP0)?LPDAC0:LPDAC1;
+  lploop_cfg.LpDacCfg.DacData12Bit = pLPTIAOffsetCal->DacData12Bit;
+  lploop_cfg.LpDacCfg.DacData6Bit = pLPTIAOffsetCal->DacData6Bit;  
+  lploop_cfg.LpDacCfg.DataRst = bFALSE;
+  lploop_cfg.LpDacCfg.LpDacRef = LPDACREF_2P5;
+  lploop_cfg.LpDacCfg.LpDacSrc = LPDACSRC_MMR;
+  lploop_cfg.LpDacCfg.LpDacVzeroMux = pLPTIAOffsetCal->LpDacVzeroMux;
+  lploop_cfg.LpDacCfg.LpDacSW = LPDACSW_VZERO2LPTIA;
+  lploop_cfg.LpDacCfg.LpDacVbiasMux = LPDACVBIAS_12BIT;
+  lploop_cfg.LpDacCfg.PowerEn = bTRUE;
+  AD5940_LPLoopCfgS(&lploop_cfg);
+
+  /* Initialize ADC filters ADCRawData-->SINC3-->SINC2+NOTCH. Use SIN2 data for calibration-->Lower noise */
+  adc_filter.ADCSinc3Osr = pLPTIAOffsetCal->ADCSinc3Osr;
+  adc_filter.ADCSinc2Osr = pLPTIAOffsetCal->ADCSinc2Osr;  /* 800KSPS/4/1333 = 150SPS */
+  adc_filter.ADCAvgNum = ADCAVGNUM_2;               /* Don't care about it. Average function is only used for DFT */
+  adc_filter.ADCRate = bADCClk32MHzMode?ADCRATE_1P6MHZ:ADCRATE_800KHZ;        /* If ADC clock is 32MHz, then set it to ADCRATE_1P6MHZ. Default is 16MHz, use ADCRATE_800KHZ. */
+  adc_filter.BpNotch = bTRUE;                       /* SINC2+Notch is one block, when bypass notch filter, we can get fresh data from SINC2 filter. */
+  adc_filter.BpSinc3 = bFALSE;                      /* We use SINC3 filter. */
+  adc_filter.Sinc2NotchEnable = bTRUE;              /* Enable the SINC2+Notch block. You can also use function AD5940_AFECtrlS */
+  AD5940_ADCFilterCfgS(&adc_filter);
+  /* Initialize ADC MUx and PGA */
+  if(pLPTIAOffsetCal->LpAmpSel == LPAMP0)
+  {
+    adc_base.ADCMuxP = ADCMUXP_LPTIA0_P;      
+    adc_base.ADCMuxN = ADCMUXN_LPTIA0_N;
+  }
+  else
+  {
+    adc_base.ADCMuxP = ADCMUXP_LPTIA1_P;      
+    adc_base.ADCMuxN = ADCMUXN_LPTIA1_N;
+  }
+  adc_base.ADCPga = pLPTIAOffsetCal->ADCPga;                 /* Set correct Gain value. */
+  AD5940_ADCBaseCfgS(&adc_base);
+  /* Turn ON ADC and its reference. And SINC2. */
+  AD5940_AFECtrlS(AFECTRL_ALL, bFALSE); /* Disable all firstly, we only enable things we use */
+  AD5940_AFECtrlS(AFECTRL_ADCPWR|AFECTRL_HPREFPWR|AFECTRL_SINC2NOTCH, bTRUE);
+  AD5940_Delay10us(25);                     /* Wait 250us for reference power up */
+  /* INTC configure and open calibration lock */
+  INTCCfg = AD5940_INTCGetCfg(AFEINTC_1);
+  AD5940_INTCCfg(AFEINTC_1, AFEINTSRC_SINC2RDY, bTRUE); /* Enable SINC2 Interrupt in INTC1 */
+  AD5940_WriteReg(REG_AFE_CALDATLOCK, KEY_CALDATLOCK);  /* Unlock KEY */
+
+  /* Do offset calibration. */
+  {
+    int32_t ExpectedCode = 0x8000;        /* Ideal ADC output */
+    AD5940_WriteReg(REG_AFE_ADCOFFSETLPTIA0, 0);   /* Reset offset register */
+
+    if(pLPTIAOffsetCal->SettleTime10us > 0)
+      AD5940_Delay10us(pLPTIAOffsetCal->SettleTime10us);  /* Delay 10us */
+    time_out = pLPTIAOffsetCal->TimeOut10us;   /* Reset time out counter */
+    ADCCode = __AD5940_TakeMeasurement(&time_out);  /* Turn on ADC to get one valid data and then turn off ADC. */
+    if(time_out == 0)
+    {
+      error = AD5940ERR_TIMEOUT;
+      goto LPTIAOFFSETCALERROR;
+    }  /* Time out error. */
+    /* Calculate and write the result to registers before gain calibration */
+    ADCCode = ((ExpectedCode - ADCCode)<<3);  /* We will shift back 1bit below */
+    ADCCode = ((ADCCode+1)>>1); /* Round 0.5 */
+    if((ADCCode > 0x3fff) ||
+        (ADCCode < -0x4000))    /* The register used for offset calibration is limited to -0x4000 to 0x3fff */
+    {
+      error = AD5940ERR_CALOR;
+      goto LPTIAOFFSETCALERROR;
+    }
+    ADCCode &= 0x7fff;
+    if(pLPTIAOffsetCal->LpAmpSel == LPAMP0)
+      AD5940_WriteReg(REG_AFE_ADCOFFSETLPTIA0, ADCCode);
+    else
+      AD5940_WriteReg(REG_AFE_ADCOFFSETLPTIA1, ADCCode);
+  }
+  /* Restore INTC1 SINC2 configure */
+  if(INTCCfg&AFEINTSRC_SINC2RDY);
+  else
+    AD5940_INTCCfg(AFEINTC_1, AFEINTSRC_SINC2RDY, bFALSE); /* Disable SINC2 Interrupt */
+  
+  AD5940_WriteReg(REG_AFE_CALDATLOCK, 0);  /* Lock KEY */
+  /* Done */
+  return AD5940ERR_OK;
+
+LPTIAOFFSETCALERROR:
+  AD5940_ADCConvtCtrlS(bFALSE);  /* Stop conversion */
+  AD5940_WriteReg(REG_AFE_CALDATLOCK, 0);  /* Lock KEY */
+  return error;
+}
+
+/**
+ * @brief Calibrate HSTIA offset-ongoing.
+ * @param pHSTIAOffsetCal: pointer to configuration.
+ * @return AD5940ERR_OK.
+**/
+AD5940Err AD5940_HSTIAOffsetCal(LPTIAOffsetCal_Type *pHSTIAOffsetCal)
+{
+  return AD5940ERR_OK;
+}
+
+/**
+ * @brief Measure HSTIA internal RTIA impedance.
+ * @param pCalCfg: pointer to calibration structure.
+ * @param pResult:  Pointer to a variable that used to store result. 
+ *                  If bPolarResult in structure is set, then use type fImpPol_Type otherwise use fImpCar_Type. 
+ * @return AD5940ERR_OK if succeed.
+**/
+AD5940Err AD5940_HSRtiaCal(HSRTIACal_Type *pCalCfg, void *pResult)
+{
+  AFERefCfg_Type aferef_cfg;
+  HSLoopCfg_Type hs_loop;
+  DSPCfg_Type dsp_cfg;
+  uint32_t INTCCfg;
+  
+  BoolFlag bADCClk32MHzMode = bFALSE;
+  uint32_t ExcitBuffGain = EXCITBUFGAIN_2;
+  uint32_t HsDacGain = HSDACGAIN_1;
+
+  float ExcitVolt; /* Excitation voltage, unit is mV */
+  uint32_t RtiaVal;
+  uint32_t const HpRtiaTable[]={200,1000,5000,10000,20000,40000,80000,160000,0};
+  uint32_t WgAmpWord;
+
+  iImpCar_Type DftRcal, DftRtia;
+
+  if(pCalCfg == NULL) return AD5940ERR_NULLP;
+  if(pCalCfg->fRcal == 0)
+    return AD5940ERR_PARA;
+  if(pCalCfg->HsTiaCfg.HstiaRtiaSel > HSTIARTIA_160K)
+    return AD5940ERR_PARA;
+  if(pCalCfg->HsTiaCfg.HstiaRtiaSel == HSTIARTIA_OPEN)
+    return AD5940ERR_PARA; /* Do not support calibrating DE0-RTIA */
+  if(pResult == NULL)
+      return AD5940ERR_NULLP;
+
+  if(pCalCfg->AdcClkFreq > (32000000*0.8))
+    bADCClk32MHzMode = bTRUE; 
+
+  /* Calculate the excitation voltage we should use based on RCAL/Rtia */
+  RtiaVal = HpRtiaTable[pCalCfg->HsTiaCfg.HstiaRtiaSel];
+  /*
+    DAC output voltage calculation
+    Note: RCAL value should be similar to RTIA so the accuracy is best.
+    HSTIA output voltage should be limited to 0.2V to AVDD-0.2V, with 1.1V bias. We use 80% of this range for safe. 
+    Because the bias voltage is fixed to 1.1V, so for AC signal maximum amplitude is 1.1V-0.2V = 0.9Vp. That's 1.8Vpp.
+    Formula is:    ExcitVolt(in mVpp) = (1800mVpp*80% / RTIA) * RCAL
+    ADC input range is +-1.5V which is enough for calibration.
+    
+  */
+  ExcitVolt = 1800*0.8*pCalCfg->fRcal/RtiaVal;
+
+  if(ExcitVolt <= 800*0.05) /* Voltage is so small that we can enable the attenuator of DAC(1/5) and Excitation buffer(1/4). 800mVpp is the DAC output voltage */
+  {
+    ExcitBuffGain = EXCITBUFGAIN_0P25;
+    HsDacGain = HSDACGAIN_0P2;
+    /* Excitation buffer voltage full range is 800mVpp*0.05 = 40mVpp */
+    WgAmpWord = ((uint32_t)(ExcitVolt/40*2047*2)+1)>>1; /* Assign value with rounding (0.5 LSB error) */
+  }
+  else if(ExcitVolt <= 800*0.25) /* Enable Excitation buffer attenuator */
+  {
+    ExcitBuffGain = EXCITBUFGAIN_0P25;
+    HsDacGain = HSDACGAIN_1;
+    /* Excitation buffer voltage full range is 800mVpp*0.25 = 200mVpp */
+    WgAmpWord = ((uint32_t)(ExcitVolt/200*2047*2)+1)>>1; /* Assign value with rounding (0.5 LSB error) */
+  }
+  else if(ExcitVolt <= 800*0.4) /* Enable DAC attenuator */
+  {
+    ExcitBuffGain = EXCITBUFGAIN_2;
+    HsDacGain = HSDACGAIN_0P2;
+    /* Excitation buffer voltage full range is 800mVpp*0.4 = 320mV */
+    WgAmpWord = ((uint32_t)(ExcitVolt/320*2047*2)+1)>>1; /* Assign value with rounding (0.5 LSB error) */
+  }
+  else /* No attenuator is needed. This is the best condition which means RTIA is close to RCAL */
+  {
+    ExcitBuffGain = EXCITBUFGAIN_2;
+    HsDacGain = HSDACGAIN_1;
+    /* Excitation buffer voltage full range is 800mVpp*2=1600mVpp */
+    WgAmpWord = ((uint32_t)(ExcitVolt/1600*2047*2)+1)>>1; /* Assign value with rounding (0.5 LSB error) */
+  }
+
+  if(WgAmpWord > 0x7ff)
+  WgAmpWord = 0x7ff;
+  
+  /*INTC configuration */
+  INTCCfg = AD5940_INTCGetCfg(AFEINTC_1);
+  AD5940_INTCCfg(AFEINTC_1, AFEINTSRC_DFTRDY, bTRUE); /* Enable SINC2 Interrupt in INTC1 */
+  
+  AD5940_AFECtrlS(AFECTRL_ALL, bFALSE);  /* Init all to disable state */
+  /* Configure reference system */
+  aferef_cfg.HpBandgapEn = bTRUE;
+  aferef_cfg.Hp1V1BuffEn = bTRUE;
+  aferef_cfg.Hp1V8BuffEn = bTRUE;
+  aferef_cfg.Disc1V1Cap = bFALSE;
+  aferef_cfg.Disc1V8Cap = bFALSE;
+  aferef_cfg.Hp1V8ThemBuff = bFALSE;
+  aferef_cfg.Hp1V8Ilimit = bFALSE;
+  aferef_cfg.Lp1V1BuffEn = bFALSE;
+  aferef_cfg.Lp1V8BuffEn = bFALSE;
+  aferef_cfg.LpBandgapEn = bFALSE;
+  aferef_cfg.LpRefBufEn = bFALSE;
+  aferef_cfg.LpRefBoostEn = bFALSE;
+  AD5940_REFCfgS(&aferef_cfg);	
+  /* Configure HP Loop */
+  hs_loop.HsDacCfg.ExcitBufGain = ExcitBuffGain;
+  hs_loop.HsDacCfg.HsDacGain = HsDacGain;
+  hs_loop.HsDacCfg.HsDacUpdateRate = 7; /* Set it to highest update rate */
+  memcpy(&hs_loop.HsTiaCfg, &pCalCfg->HsTiaCfg, sizeof(pCalCfg->HsTiaCfg));
+  hs_loop.SWMatCfg.Dswitch = SWD_RCAL0;
+  hs_loop.SWMatCfg.Pswitch = SWP_RCAL0;
+  hs_loop.SWMatCfg.Nswitch = SWN_RCAL1;
+  hs_loop.SWMatCfg.Tswitch = SWT_RCAL1|SWT_TRTIA;
+  hs_loop.WgCfg.WgType = WGTYPE_SIN;
+  hs_loop.WgCfg.GainCalEn = bTRUE;
+  hs_loop.WgCfg.OffsetCalEn = bTRUE;
+  hs_loop.WgCfg.SinCfg.SinFreqWord = AD5940_WGFreqWordCal(pCalCfg->fFreq, pCalCfg->SysClkFreq);
+  hs_loop.WgCfg.SinCfg.SinAmplitudeWord = WgAmpWord;
+  hs_loop.WgCfg.SinCfg.SinOffsetWord = 0;
+  hs_loop.WgCfg.SinCfg.SinPhaseWord = 0;
+  AD5940_HSLoopCfgS(&hs_loop);
+  /* Configure DSP */
+  dsp_cfg.ADCBaseCfg.ADCMuxN = ADCMUXN_N_NODE;
+  dsp_cfg.ADCBaseCfg.ADCMuxP = ADCMUXP_P_NODE;
+  dsp_cfg.ADCBaseCfg.ADCPga = ADCPGA_1P5;
+  AD5940_StructInit(&dsp_cfg.ADCDigCompCfg, sizeof(dsp_cfg.ADCDigCompCfg));
+  dsp_cfg.ADCFilterCfg.ADCAvgNum = ADCAVGNUM_16;  /* Don't care because it's disabled */
+  dsp_cfg.ADCFilterCfg.ADCRate = bADCClk32MHzMode?ADCRATE_1P6MHZ:ADCRATE_800KHZ;
+  dsp_cfg.ADCFilterCfg.ADCSinc2Osr = pCalCfg->ADCSinc2Osr;
+  dsp_cfg.ADCFilterCfg.ADCSinc3Osr = pCalCfg->ADCSinc3Osr;
+  dsp_cfg.ADCFilterCfg.BpNotch = bTRUE;
+  dsp_cfg.ADCFilterCfg.BpSinc3 = bFALSE;
+  dsp_cfg.ADCFilterCfg.Sinc2NotchEnable = bTRUE;
+  
+  memcpy(&dsp_cfg.DftCfg, &pCalCfg->DftCfg, sizeof(pCalCfg->DftCfg));
+  memset(&dsp_cfg.StatCfg, 0, sizeof(dsp_cfg.StatCfg));
+  AD5940_DSPCfgS(&dsp_cfg);
+
+  /* Enable all of them. They are automatically turned off during hibernate mode to save power */
+  AD5940_AFECtrlS(AFECTRL_HSTIAPWR|AFECTRL_INAMPPWR|AFECTRL_EXTBUFPWR|\
+                /*AFECTRL_WG|*/AFECTRL_DACREFPWR|AFECTRL_HSDACPWR|\
+                AFECTRL_SINC2NOTCH, bTRUE);
+  
+  AD5940_AFECtrlS(AFECTRL_WG|AFECTRL_ADCPWR, bTRUE);  /* Enable Waveform generator, ADC power */
+  //wait for sometime.
+  AD5940_Delay10us(25);
+  AD5940_AFECtrlS(AFECTRL_ADCCNV|AFECTRL_DFT, bTRUE);  /* Start ADC convert and DFT */
+  /* Wait until DFT ready */
+  while(AD5940_INTCTestFlag(AFEINTC_1, AFEINTSRC_DFTRDY) == bFALSE);  
+  AD5940_AFECtrlS(AFECTRL_ADCCNV|AFECTRL_DFT|AFECTRL_WG|AFECTRL_ADCPWR, bFALSE);  /* Stop ADC convert and DFT */
+  AD5940_INTCClrFlag(AFEINTSRC_DFTRDY);
+  
+  DftRcal.Real = AD5940_ReadAfeResult(AFERESULT_DFTREAL);
+  DftRcal.Image = AD5940_ReadAfeResult(AFERESULT_DFTIMAGE);
+
+  AD5940_ADCMuxCfgS(ADCMUXP_HSTIA_P, ADCMUXN_HSTIA_N);
+  AD5940_AFECtrlS(AFECTRL_WG|AFECTRL_ADCPWR, bTRUE);  /* Enable Waveform generator, ADC power */
+  //wait for sometime.
+  AD5940_Delay10us(25);
+  AD5940_AFECtrlS(AFECTRL_ADCCNV|AFECTRL_DFT, bTRUE);  /* Start ADC convert and DFT */
+  /* Wait until DFT ready */
+  while(AD5940_INTCTestFlag(AFEINTC_1, AFEINTSRC_DFTRDY) == bFALSE);  
+  AD5940_AFECtrlS(AFECTRL_ADCCNV|AFECTRL_DFT|AFECTRL_WG|AFECTRL_ADCPWR, bFALSE);  /* Stop ADC convert and DFT */
+  AD5940_INTCClrFlag(AFEINTSRC_DFTRDY);
+
+  DftRtia.Real = AD5940_ReadAfeResult(AFERESULT_DFTREAL);
+  DftRtia.Image = AD5940_ReadAfeResult(AFERESULT_DFTIMAGE);
+  
+  if(DftRcal.Real&(1L<<17))
+    DftRcal.Real |= 0xfffc0000;
+  if(DftRcal.Image&(1L<<17))
+    DftRcal.Image |= 0xfffc0000;
+  if(DftRtia.Real&(1L<<17))
+    DftRtia.Real |= 0xfffc0000;
+  if(DftRtia.Image&(1L<<17))
+    DftRtia.Image |= 0xfffc0000;
+  /* 
+    ADC MUX is set to HSTIA_P and HSTIA_N.
+    While the current flow through RCAL and then into RTIA, the current direction should be from HSTIA_N to HSTIA_P if we 
+    measure the voltage across RCAL by MUXSELP_P_NODE and MUXSELN_N_NODE.
+    So here, we add a negative sign to results
+  */
+  DftRtia.Image = -DftRtia.Image;
+  DftRtia.Real = -DftRtia.Real; /* Current is measured by MUX HSTIA_P-HSTIA_N. It should be  */
+   /*
+      The impedance engine inside of AD594x give us Real part and Imaginary part of DFT. Due to technology used, the Imaginary 
+      part in register is the opposite number. So we add a negative sign on the Imaginary part of results. 
+   */
+  DftRtia.Image = -DftRtia.Image;
+  DftRcal.Image = -DftRcal.Image;
+
+  fImpCar_Type temp;
+  temp = AD5940_ComplexDivInt(&DftRtia, &DftRcal);
+  temp.Real *= pCalCfg->fRcal;
+  temp.Image *= pCalCfg->fRcal;
+  if(pCalCfg->bPolarResult == bFALSE)
+  {
+    *(fImpCar_Type*)pResult = temp;
+  }
+  else
+  {
+    ((fImpPol_Type*)pResult)->Magnitude = AD5940_ComplexMag(&temp);
+    ((fImpPol_Type*)pResult)->Phase = AD5940_ComplexPhase(&temp);
+  }
+  
+  /* Restore INTC1 DFT configure */
+  if(INTCCfg&AFEINTSRC_DFTRDY);
+  else
+    AD5940_INTCCfg(AFEINTC_1, AFEINTSRC_DFTRDY, bFALSE); /* Disable DFT Interrupt */
+
+  return AD5940ERR_OK;
+}
+
+/**
+ * @brief Measure LPTIA internal RTIA impedance with HSTIA. This is the recommended method for LPTIA RTIA calibration.
+ * @param pCalCfg: pointer to calibration structure.
+ * @param pResult:  Pointer to a variable that used to store result. 
+ *                  If bPolarResult in structure is set, then use type fImpPol_Type otherwise use fImpCar_Type. 
+ * @return AD5940ERR_OK if succeed.
+**/
+AD5940Err AD5940_LPRtiaCal(LPRTIACal_Type *pCalCfg, void *pResult)
+{
+  HSLoopCfg_Type hs_loop;
+  LPLoopCfg_Type lp_loop;
+  DSPCfg_Type dsp_cfg;
+  ADCBaseCfg_Type *pADCBaseCfg; 
+  SWMatrixCfg_Type *pSWCfg;  
+  uint32_t INTCCfg, reg_afecon;
+  BoolFlag bADCClk32MHzMode = bFALSE;
+  BoolFlag bDCMode = bFALSE;                /* Indicate if frequency is 0, which means we calibrate at DC. */
+
+  float ExcitVolt; /* Excitation voltage, unit is mV */
+  uint32_t RtiaVal;
+  /* RTIA value table when RLOAD set to 100Ohm */
+  uint32_t const LpRtiaTable[]={0,110,1000,2000,3000,4000,6000,8000,10000,12000,16000,20000,24000,30000,32000,40000,48000,64000,85000,96000,100000,120000,128000,160000,196000,256000,512000};
+  float const ADCPGAGainTable[] = {1, 1.5, 2, 4, 9};
+  uint32_t WgAmpWord;
+
+  uint32_t ADCPgaGainRtia, ADCPgaGainRcal;
+  float GainRatio;
+
+  iImpCar_Type DftRcal, DftRtia;
+
+  if(pCalCfg == NULL)  return AD5940ERR_NULLP;  /* Parameters illegal */
+  
+  if(pCalCfg->fRcal == 0)
+    return AD5940ERR_PARA;
+  if(pCalCfg->LpTiaRtia > LPTIARTIA_512K)
+    return AD5940ERR_PARA;
+  if(pCalCfg->LpTiaRtia == LPTIARTIA_OPEN)
+    return AD5940ERR_PARA; /* Not supported now. By setting RTIA to open and set corresponding switches can calibrate external RTIA */
+  if(pResult == NULL)
+      return AD5940ERR_NULLP;
+
+  if(pCalCfg->AdcClkFreq > (32000000*0.8))
+    bADCClk32MHzMode = bTRUE;   /* Clock frequency is high. */
+  if(pCalCfg->fFreq == 0.0f)    /* Frequency is zero means we calibrate RTIA at DC. */
+    bDCMode = bTRUE;
+  /* Init two pointers */
+  pSWCfg = &hs_loop.SWMatCfg;
+  pADCBaseCfg = &dsp_cfg.ADCBaseCfg;
+  /* Calculate the excitation voltage we should use based on RCAL/Rtia */
+  RtiaVal = LpRtiaTable[pCalCfg->LpTiaRtia];
+  /*
+   * DAC output voltage calculation
+   * Note: RCAL value should be similar to RTIA so the accuracy is best.
+   * LPTIA output voltage should be limited to 0.3V to AVDD-0.4V, with 1.3V bias. We use 80% of this range for safe. 
+   * That's 2.0Vpp*80%@2.7V AVDD
+   * Formula is:    ExcitVolt(in mVpp) = (2000mVpp*80% / RTIA) * RCAL
+   * ADC input range is +-1.5V which is enough for calibration.
+   * Limitations:
+   * Note: HSTIA output range is AVDD-0.4V to AGND+0.2V
+   * HSTIA input common voltage range is 0.3V to AVDD-0.7V;
+   * When AVDD is 2.7V, the input range is 0.3V to 2.0V; 
+   * If we set Vbias to 1.3V, then maximum AC signal is 0.7Vp*2 = 1.4Vpp.
+   * Maximum AC signal is further limited by HSTIA RTIA=200Ohm, when RCAL is 200Ohm(for ADuCM355). The maximum output of HSTIA is limited to 2.3V.
+   * Maximum Vzero voltage is 1.9V when Rcal is 200Ohm and Switch On resistance is 50Ohm*2. Vzero_max = 1.3V + (2.3V-1.3V)/(200+200+50*2)*300. 
+   * Maximum AC signal is (1.9-1.3)*2 = 1.2Vpp(for ADuCM355, RCAl=200Ohm).
+  */
+ /** @cond */
+  #define MAXVOLT_P2P 1400  /* Maximum peak to peak voltage 1200mV for ADuCM355. */  
+                            /* Maximum peak2peak voltage for AD5940 10kOhm RCAL is 1400mV */
+  #define __MAXVOLT_AMP_CODE  (MAXVOLT_P2P*2047L/2200)
+ /** @endcond */
+  ExcitVolt = 2000*0.8*pCalCfg->fRcal/RtiaVal;
+  WgAmpWord = ((uint32_t)(ExcitVolt/2200*2047*2)+1)>>1; /* Assign value with rounding (0.5 LSB error) */
+  if(WgAmpWord > __MAXVOLT_AMP_CODE)
+    WgAmpWord = __MAXVOLT_AMP_CODE;
+  /**
+   * Determine the best ADC PGA gain for both RCAL and RTIA voltage measurement.
+  */
+  {
+    float RtiaVolt, RcalVolt, temp;
+    ExcitVolt = WgAmpWord*2000.0f/2047; /* 2000mVpp -->ExcitVolt in Peak to Peak unit */
+    RtiaVolt = ExcitVolt/(pCalCfg->fRcal + 100)*RtiaVal;
+    RcalVolt = RtiaVolt/RtiaVal*pCalCfg->fRcal;
+    /* The input range of ADC is 1.5Vp, we calculate how much gain we need */
+    temp = 3000.0f/RcalVolt;
+    if(temp >= 9.0f)  ADCPgaGainRcal = ADCPGA_9;
+    else if(temp >= 4.0f) ADCPgaGainRcal = ADCPGA_4;
+    else if(temp >= 2.0f) ADCPgaGainRcal = ADCPGA_2;
+    else if(temp >= 1.5f) ADCPgaGainRcal = ADCPGA_1P5;
+    else ADCPgaGainRcal = ADCPGA_1;
+    temp = 3000.0f/RtiaVolt;
+    if(temp >= 9.0f)  ADCPgaGainRtia = ADCPGA_9;
+    else if(temp >= 4.0f) ADCPgaGainRtia = ADCPGA_4;
+    else if(temp >= 2.0f) ADCPgaGainRtia = ADCPGA_2;
+    else if(temp >= 1.5f) ADCPgaGainRtia = ADCPGA_1P5;
+    else ADCPgaGainRtia = ADCPGA_1;
+    GainRatio = ADCPGAGainTable[ADCPgaGainRtia]/ADCPGAGainTable[ADCPgaGainRcal];
+  }
+  reg_afecon = AD5940_ReadReg(REG_AFE_AFECON);
+  /* INTC configuration */
+  INTCCfg = AD5940_INTCGetCfg(AFEINTC_1);
+  AD5940_INTCCfg(AFEINTC_1, AFEINTSRC_DFTRDY|AFEINTSRC_SINC2RDY, bTRUE); /* Enable SINC2 Interrupt in INTC1 */
+  AD5940_INTCClrFlag(AFEINTSRC_ALLINT);
+
+  AD5940_AFECtrlS(AFECTRL_ALL, bFALSE);  /* Init all to disable state */
+  /* Configure reference system */
+	__AD5940_ReferenceON();
+	/* Configure DSP */
+	AD5940_StructInit(&dsp_cfg, sizeof(dsp_cfg));
+	dsp_cfg.ADCFilterCfg.ADCAvgNum = ADCAVGNUM_16;  /* Don't care because it's disabled */
+	dsp_cfg.ADCFilterCfg.ADCRate = bADCClk32MHzMode?ADCRATE_1P6MHZ:ADCRATE_800KHZ;
+	dsp_cfg.ADCFilterCfg.ADCSinc2Osr = pCalCfg->ADCSinc2Osr;
+	dsp_cfg.ADCFilterCfg.ADCSinc3Osr = pCalCfg->ADCSinc3Osr;
+	dsp_cfg.ADCFilterCfg.BpNotch = bTRUE;
+	dsp_cfg.ADCFilterCfg.BpSinc3 = bFALSE;
+	dsp_cfg.ADCFilterCfg.Sinc2NotchEnable = bTRUE;
+	memcpy(&dsp_cfg.DftCfg, &pCalCfg->DftCfg, sizeof(pCalCfg->DftCfg));
+	AD5940_DSPCfgS(&dsp_cfg);
+  /* Configure LP Loop */
+  AD5940_StructInit(&lp_loop, sizeof(lp_loop));
+  /* Configure LP Amplifies(LPPA and LPTIA). We won't use LP-PA */
+  lp_loop.LpDacCfg.LpdacSel = (pCalCfg->LpAmpSel  == LPAMP0)?LPDAC0:LPDAC1;
+	lp_loop.LpDacCfg.DacData12Bit = 0x800;                 		/* Controlled by WG */
+  lp_loop.LpDacCfg.DacData6Bit = 32;                    /* middle scale value */
+  lp_loop.LpDacCfg.DataRst =bFALSE;                    	/* Do not keep DATA registers at reset status */
+  lp_loop.LpDacCfg.LpDacSW = LPDACSW_VBIAS2LPPA|LPDACSW_VZERO2HSTIA;
+  lp_loop.LpDacCfg.LpDacRef = LPDACREF_2P5;            	/* Select internal 2.5V reference */
+  lp_loop.LpDacCfg.LpDacSrc = LPDACSRC_WG;             	/* The LPDAC data comes from WG not MMR in this case */
+  lp_loop.LpDacCfg.LpDacVbiasMux = LPDACVBIAS_6BIT;    	/* Connect Vbias signal to 6Bit LPDAC output */
+  lp_loop.LpDacCfg.LpDacVzeroMux = LPDACVZERO_12BIT;   	/* Connect Vzero signal to 12bit LPDAC output */
+  lp_loop.LpDacCfg.PowerEn = bTRUE;                    	/* Power up LPDAC */
+
+  lp_loop.LpAmpCfg.LpAmpSel = pCalCfg->LpAmpSel;
+  lp_loop.LpAmpCfg.LpAmpPwrMod = pCalCfg->LpAmpPwrMod;  /* Set low power amplifiers to normal power mode */
+  lp_loop.LpAmpCfg.LpPaPwrEn = bTRUE;                  	/* Enable LP PA(potential-stat amplifier) power */
+  lp_loop.LpAmpCfg.LpTiaPwrEn = bTRUE;                	/* Enable LPTIA*/
+  lp_loop.LpAmpCfg.LpTiaRload = LPTIARLOAD_100R;
+  lp_loop.LpAmpCfg.LpTiaRtia = pCalCfg->LpTiaRtia;
+  lp_loop.LpAmpCfg.LpTiaRf = LPTIARF_OPEN;
+  lp_loop.LpAmpCfg.LpTiaSW = LPTIASW(6)|LPTIASW(8)|(pCalCfg->bWithCtia==bTRUE?LPTIASW(5)/*|LPTIASW(9)*/:0);
+  AD5940_LPLoopCfgS(&lp_loop);
+  /* Configure HS Loop */
+  AD5940_StructInit(&hs_loop, sizeof(hs_loop));
+  /* Take care of HSTIA, we need to disconnect internal RTIA because it connects to Tswitch directly. */
+	hs_loop.HsTiaCfg.DiodeClose = bFALSE;
+  hs_loop.HsTiaCfg.HstiaBias = (pCalCfg->LpAmpSel  == LPAMP0)?HSTIABIAS_VZERO0:HSTIABIAS_VZERO1;
+  hs_loop.HsTiaCfg.HstiaCtia = 31;
+  hs_loop.HsTiaCfg.HstiaDeRload = HSTIADERLOAD_OPEN;
+  hs_loop.HsTiaCfg.HstiaDeRtia = HSTIADERTIA_OPEN;
+  hs_loop.HsTiaCfg.HstiaDe1Rload = HSTIADERLOAD_OPEN;
+  hs_loop.HsTiaCfg.HstiaDe1Rtia = HSTIADERTIA_OPEN;
+  hs_loop.HsTiaCfg.HstiaRtiaSel = HSTIARTIA_200;
+  /* Configure HSDAC */
+	hs_loop.HsDacCfg.ExcitBufGain = 0;
+  hs_loop.HsDacCfg.HsDacGain = 0;  					/* Don't care */
+  hs_loop.HsDacCfg.HsDacUpdateRate = 255;  	/* Lowest for LPDAC */
+
+  hs_loop.SWMatCfg.Dswitch = SWD_RCAL0|((pCalCfg->LpAmpSel  == LPAMP0)?SWD_SE0:SWD_SE1);
+  hs_loop.SWMatCfg.Pswitch = SWP_RCAL0;
+  hs_loop.SWMatCfg.Nswitch = SWN_RCAL1;
+  hs_loop.SWMatCfg.Tswitch = SWT_TRTIA|SWT_RCAL1;
+  if(bDCMode)
+  {
+    int32_t time_out = -1;    /* Always wait. */
+    int32_t offset_rcal, offset_rtia;  
+    /* Configure WG */
+    hs_loop.WgCfg.WgType = WGTYPE_MMR;
+    hs_loop.WgCfg.WgCode = WgAmpWord;       /* Amplitude word is exactly the maximum DC voltage we could use */
+    hs_loop.WgCfg.GainCalEn = bFALSE;		    /* We don't have calibration value for LPDAC, so we don't use it. */
+    hs_loop.WgCfg.OffsetCalEn = bFALSE;
+    AD5940_HSLoopCfgS(&hs_loop);
+    AD5940_WGDACCodeS(WgAmpWord + 0x800);
+		AD5940_AFECtrlS(AFECTRL_HSTIAPWR|AFECTRL_INAMPPWR|AFECTRL_WG|AFECTRL_ADCPWR, bTRUE); /* Apply voltage to loop and turn on ADC */
+    /* Do offset measurement */
+    pSWCfg->Dswitch = SWD_RCAL0;//|SWD_SE0;   /* Disconnect SE0 for now to measure the offset voltage. */
+    pSWCfg->Pswitch = SWP_RCAL0;
+    pSWCfg->Nswitch = SWN_RCAL1;
+    pSWCfg->Tswitch = SWT_TRTIA|SWT_RCAL1;
+    AD5940_SWMatrixCfgS(pSWCfg);    
+    AD5940_Delay10us(1000);   /* Wait some time here. */
+    /* Measure RCAL channel voltage offset */
+    pADCBaseCfg->ADCMuxN = ADCMUXN_N_NODE;
+    pADCBaseCfg->ADCMuxP = ADCMUXP_P_NODE;
+    pADCBaseCfg->ADCPga = ADCPgaGainRcal;
+    AD5940_ADCBaseCfgS(pADCBaseCfg);
+    AD5940_Delay10us(50);   /* Wait some time here. */
+    offset_rcal = __AD5940_TakeMeasurement(&time_out);  /* Turn on ADC to get one valid data and then turn off ADC. */
+    /* Measure RTIA channel voltage offset */
+    if(pCalCfg->LpAmpSel == LPAMP0)
+    {
+      pADCBaseCfg->ADCMuxN = ADCMUXN_LPTIA0_N;
+      pADCBaseCfg->ADCMuxP = ADCMUXP_LPTIA0_P;
+    }else
+    {
+      pADCBaseCfg->ADCMuxN = ADCMUXN_LPTIA1_N;
+      pADCBaseCfg->ADCMuxP = ADCMUXP_LPTIA1_P;
+    }
+    pADCBaseCfg->ADCPga = ADCPgaGainRtia;    
+    AD5940_ADCBaseCfgS(pADCBaseCfg);
+    AD5940_Delay10us(50);   /* Wait some time here. */
+    offset_rtia = __AD5940_TakeMeasurement(&time_out);  /* Turn on ADC to get one valid data and then turn off ADC. */
+    /* Connect LPTIA loop, let current flow to RTIA. */
+    pSWCfg->Dswitch = SWD_RCAL0|((pCalCfg->LpAmpSel == LPAMP0)?SWD_SE0:SWD_SE1);
+    pSWCfg->Pswitch = SWP_RCAL0;
+    pSWCfg->Nswitch = SWN_RCAL1;
+    pSWCfg->Tswitch = SWT_TRTIA|SWT_RCAL1;
+    AD5940_SWMatrixCfgS(pSWCfg);
+    AD5940_Delay10us(1000);   /* Wait some time here. */
+		/* Measure RCAL */
+    pADCBaseCfg = &dsp_cfg.ADCBaseCfg;
+    pADCBaseCfg->ADCMuxN = ADCMUXN_N_NODE;
+    pADCBaseCfg->ADCMuxP = ADCMUXP_P_NODE;
+    pADCBaseCfg->ADCPga = ADCPgaGainRcal;
+    AD5940_ADCBaseCfgS(pADCBaseCfg);
+    AD5940_Delay10us(50);   /* Wait some time here. */
+    DftRcal.Real = (int32_t)__AD5940_TakeMeasurement(&time_out)- offset_rcal;
+    DftRcal.Image = 0;
+		/* Measure RTIA */    
+    if(pCalCfg->LpAmpSel == LPAMP0)
+    {
+      pADCBaseCfg->ADCMuxN = ADCMUXN_LPTIA0_N;
+      pADCBaseCfg->ADCMuxP = ADCMUXP_LPTIA0_P;
+    }else
+    {
+      pADCBaseCfg->ADCMuxN = ADCMUXN_LPTIA1_N;
+      pADCBaseCfg->ADCMuxP = ADCMUXP_LPTIA1_P;
+    }
+    pADCBaseCfg->ADCPga = ADCPgaGainRtia;
+    AD5940_ADCBaseCfgS(pADCBaseCfg);
+    AD5940_Delay10us(50);   /* Wait some time here. */
+    DftRtia.Real = (int32_t)__AD5940_TakeMeasurement(&time_out)- offset_rtia;
+    DftRtia.Image = 0;
+  }
+  else
+  {
+		hs_loop.WgCfg.SinCfg.SinAmplitudeWord = WgAmpWord;
+		hs_loop.WgCfg.SinCfg.SinFreqWord = AD5940_WGFreqWordCal(pCalCfg->fFreq, pCalCfg->SysClkFreq);
+		hs_loop.WgCfg.SinCfg.SinOffsetWord = 0;
+		hs_loop.WgCfg.SinCfg.SinPhaseWord = 0;
+		hs_loop.WgCfg.WgCode = 0;
+		hs_loop.WgCfg.WgType = WGTYPE_SIN;
+    hs_loop.WgCfg.GainCalEn = bFALSE;      /* disable it */
+    hs_loop.WgCfg.OffsetCalEn = bFALSE;
+    AD5940_HSLoopCfgS(&hs_loop);
+    AD5940_INTCClrFlag(AFEINTSRC_DFTRDY);
+
+    AD5940_AFECtrlS(AFECTRL_HSTIAPWR|AFECTRL_INAMPPWR, bTRUE);
+    AD5940_Delay10us(100);      /* Wait for loop stable. */
+    pADCBaseCfg = &dsp_cfg.ADCBaseCfg;
+		/* DFT on RCAL */
+    pADCBaseCfg->ADCMuxN = ADCMUXN_N_NODE;
+    pADCBaseCfg->ADCMuxP = ADCMUXP_P_NODE;
+    pADCBaseCfg->ADCPga = ADCPgaGainRcal;
+    AD5940_ADCBaseCfgS(pADCBaseCfg);
+    AD5940_AFECtrlS(AFECTRL_ADCPWR|AFECTRL_WG, bTRUE);
+    AD5940_Delay10us(25);
+    AD5940_AFECtrlS(AFECTRL_ADCCNV|AFECTRL_DFT, bTRUE);
+    /* Wait until DFT ready */
+    while(AD5940_INTCTestFlag(AFEINTC_1, AFEINTSRC_DFTRDY) == bFALSE);  
+    AD5940_AFECtrlS(AFECTRL_ADCCNV|AFECTRL_DFT|AFECTRL_WG|AFECTRL_ADCPWR, bFALSE);  /* Stop ADC convert and DFT */
+    AD5940_INTCClrFlag(AFEINTSRC_DFTRDY);
+    DftRcal.Real = AD5940_ReadAfeResult(AFERESULT_DFTREAL);
+    DftRcal.Image = AD5940_ReadAfeResult(AFERESULT_DFTIMAGE);
+		/* DFT on RTIA */  
+    if(pCalCfg->LpAmpSel == LPAMP0)
+    {
+      pADCBaseCfg->ADCMuxN = ADCMUXN_LPTIA0_N;
+      pADCBaseCfg->ADCMuxP = ADCMUXP_LPTIA0_P;
+    }else
+    {
+      pADCBaseCfg->ADCMuxN = ADCMUXN_LPTIA1_N;
+      pADCBaseCfg->ADCMuxP = ADCMUXP_LPTIA1_P;
+    }
+    pADCBaseCfg->ADCPga = ADCPgaGainRtia;
+    AD5940_ADCBaseCfgS(pADCBaseCfg);
+    AD5940_AFECtrlS(AFECTRL_ADCPWR|AFECTRL_WG, bTRUE);
+    AD5940_Delay10us(25);
+    AD5940_AFECtrlS(AFECTRL_ADCCNV|AFECTRL_DFT, bTRUE);
+    /* Wait until DFT ready */
+    while(AD5940_INTCTestFlag(AFEINTC_1, AFEINTSRC_DFTRDY) == bFALSE);  
+    AD5940_AFECtrlS(AFECTRL_ADCCNV|AFECTRL_DFT|AFECTRL_WG|AFECTRL_ADCPWR, bFALSE);  /* Stop ADC convert and DFT */
+    AD5940_INTCClrFlag(AFEINTSRC_DFTRDY);
+    DftRtia.Real = AD5940_ReadAfeResult(AFERESULT_DFTREAL);
+    DftRtia.Image = AD5940_ReadAfeResult(AFERESULT_DFTIMAGE);
+    if(DftRcal.Real&(1L<<17))
+      DftRcal.Real |= 0xfffc0000;
+    if(DftRcal.Image&(1L<<17))
+      DftRcal.Image |= 0xfffc0000;
+    if(DftRtia.Real&(1L<<17))
+      DftRtia.Real |= 0xfffc0000;
+    if(DftRtia.Image&(1L<<17))
+      DftRtia.Image |= 0xfffc0000;
+  }
+  /*
+      The impedance engine inside of AD594x give us Real part and Imaginary part of DFT. Due to technology used, the Imaginary 
+      part in register is the opposite number. So we add a negative sign on the Imaginary part of results. 
+  */
+  DftRtia.Image = -DftRtia.Image;
+  DftRcal.Image = -DftRcal.Image;
+
+  fImpCar_Type res;
+  /* RTIA = (DftRtia.Real, DftRtia.Image)/(DftRcal.Real, DftRcal.Image)*fRcal */
+  res = AD5940_ComplexDivInt(&DftRtia, &DftRcal);
+  res.Real *= pCalCfg->fRcal/GainRatio;
+  res.Image *= pCalCfg->fRcal/GainRatio;
+  if(pCalCfg->bPolarResult == bFALSE)
+  {
+    ((fImpCar_Type*)pResult)->Real = res.Real;
+    ((fImpCar_Type*)pResult)->Image = res.Image;
+  }
+  else
+  {
+    ((fImpPol_Type*)pResult)->Magnitude = AD5940_ComplexMag(&res);
+    ((fImpPol_Type*)pResult)->Phase = AD5940_ComplexPhase(&res);
+  }
+    
+  /* Restore INTC1 DFT configure */
+  if(INTCCfg&AFEINTSRC_DFTRDY);
+  else
+    AD5940_INTCCfg(AFEINTC_1, AFEINTSRC_DFTRDY, bFALSE);    /* Disable DFT Interrupt */
+  if(INTCCfg&AFEINTSRC_SINC2RDY);
+  else
+    AD5940_INTCCfg(AFEINTC_1, AFEINTSRC_SINC2RDY, bFALSE);  /* Disable SINC2 Interrupt */
+  AD5940_WriteReg(REG_AFE_AFECON, reg_afecon);              /* Restore AFECON register */
+  /* Open all switches in switch-matrix */
+  hs_loop.SWMatCfg.Dswitch = SWD_OPEN;
+  hs_loop.SWMatCfg.Pswitch = SWP_OPEN;
+  hs_loop.SWMatCfg.Nswitch = SWN_OPEN;
+  hs_loop.SWMatCfg.Tswitch = SWT_OPEN;
+  AD5940_SWMatrixCfgS(&hs_loop.SWMatCfg);
+  
+  return AD5940ERR_OK;
+}
+
+/**
+ * @brief calibrate HSDAC output voltage using ADC.
+ * @note It acutally calibrates voltage output of excitation buffer.
+ * @param pCalCfg: pointer to configuration structure
+ * @return return AD5940ERR_OK if succeeded.
+*/
+AD5940Err AD5940_HSDACCal(HSDACCal_Type *pCalCfg)
+{
+  ADCBaseCfg_Type adc_base;
+  ADCFilterCfg_Type adc_filter;
+  HSLoopCfg_Type hsloop_cfg;
+  LPLoopCfg_Type lploop_cfg;
+  
+  /* LSB_Numerator and LSB_Denometer are used to calculate 
+  the codes to write to calibration registers depending on
+  which calibration register is used
+  There are LSB_Numerator ADC LSBs in
+  LSB_Denominator DAC Calibration LSBs*/
+  int32_t LSB_Numerator;
+  int32_t LEB_Denominator;
+  int32_t time_out;
+  int32_t ADCCode;
+  uint32_t HSDACCode = 0x800;     /* Mid scale DAC */
+  
+  uint32_t regaddr_offset;
+  uint32_t ADCPGA_Sel;
+  BoolFlag bHPMode;
+
+  if(pCalCfg == NULL) return AD5940ERR_NULLP;
+  if(pCalCfg->ExcitBufGain > 1) return AD5940ERR_PARA;
+  if(pCalCfg->HsDacGain > 1) return AD5940ERR_PARA;
+
+  bHPMode = pCalCfg->AfePwrMode == AFEPWR_HP?bTRUE:bFALSE;
+
+  switch(pCalCfg->ExcitBufGain)
+  {
+  case EXCITBUFGAIN_2:
+    regaddr_offset = bHPMode?REG_AFE_DACOFFSETHP:REG_AFE_DACOFFSET;
+    if(pCalCfg->HsDacGain == HSDACGAIN_0P2)
+    {
+      LSB_Numerator = 40;
+      LEB_Denominator = 14;
+      ADCPGA_Sel = ADCPGA_4;
+    }
+    else
+    {
+      LSB_Numerator = 7;
+      LEB_Denominator = 2;
+      ADCPGA_Sel = ADCPGA_1;
+    }
+    break;
+  case EXCITBUFGAIN_0P25:
+    regaddr_offset = bHPMode?REG_AFE_DACOFFSETATTENHP:REG_AFE_DACOFFSETATTEN;
+    if(pCalCfg->HsDacGain == HSDACGAIN_0P2)
+    {
+      LSB_Numerator = 5;
+      LEB_Denominator = 14;
+    }
+    else
+    {
+      LSB_Numerator = 25;
+      LEB_Denominator = 14;
+    }
+    ADCPGA_Sel = ADCPGA_4;
+    break;
+	default:
+		return AD5940ERR_PARA;
+  }
+
+  /* Turn On References*/
+  __AD5940_ReferenceON();
+  /* Step0.0 Initialize ADC filters ADCRawData-->SINC3-->SINC2+NOTCH. Use SIN2 data for calibration-->Lower noise */
+  adc_filter.ADCSinc3Osr = pCalCfg->ADCSinc3Osr;
+  adc_filter.ADCSinc2Osr = pCalCfg->ADCSinc2Osr;  /* 800KSPS/4/1333 = 150SPS */
+  adc_filter.ADCAvgNum = ADCAVGNUM_2;         /* Don't care about it. Average function is only used for DFT */
+  adc_filter.ADCRate = bHPMode?ADCRATE_1P6MHZ:ADCRATE_800KHZ;        /* If ADC clock is 32MHz, then set it to ADCRATE_1P6MHZ. Default is 16MHz, use ADCRATE_800KHZ. */
+  adc_filter.BpNotch = bTRUE;                 /* SINC2+Notch is one block, when bypass notch filter, we can get fresh data from SINC2 filter. */
+  adc_filter.BpSinc3 = bFALSE;                /* We use SINC3 filter. */
+  adc_filter.Sinc2NotchEnable = bTRUE;        /* Enable the SINC2+Notch block. You can also use function AD5940_AFECtrlS */
+  AD5940_ADCFilterCfgS(&adc_filter);
+  /* Step0.1 Initialize ADC basic function */
+  adc_base.ADCMuxP = ADCMUXP_P_NODE;
+  adc_base.ADCMuxN = ADCMUXN_N_NODE;
+  adc_base.ADCPga = ADCPGA_Sel;
+  AD5940_ADCBaseCfgS(&adc_base);
+  
+  /* Step0.2 Configure LPDAC to connect VZERO to HSTIA */
+  lploop_cfg.LpDacCfg.LpdacSel = LPDAC0;
+  lploop_cfg.LpDacCfg.DacData12Bit = 0x7C0;
+  lploop_cfg.LpDacCfg.DacData6Bit = 0x1F;  
+  lploop_cfg.LpDacCfg.DataRst = bFALSE;
+  lploop_cfg.LpDacCfg.LpDacRef = LPDACREF_2P5;
+  lploop_cfg.LpDacCfg.LpDacSrc = LPDACSRC_MMR;
+  lploop_cfg.LpDacCfg.LpDacVzeroMux = LPDACVZERO_6BIT;
+  lploop_cfg.LpDacCfg.LpDacVbiasMux = LPDACVBIAS_12BIT;
+  lploop_cfg.LpDacCfg.PowerEn = bTRUE;
+  lploop_cfg.LpDacCfg.LpDacSW = LPDACSW_VBIAS2LPPA|LPDACSW_VBIAS2PIN|LPDACSW_VZERO2HSTIA;
+  AD5940_LPLoopCfgS(&lploop_cfg);
+  
+  /* Step0.3 Configure HSLOOP */
+  hsloop_cfg.HsDacCfg.ExcitBufGain = pCalCfg->ExcitBufGain;
+  hsloop_cfg.HsDacCfg.HsDacGain = pCalCfg->HsDacGain;
+  hsloop_cfg.HsDacCfg.HsDacUpdateRate = bHPMode?0x7:0x1B;
+  hsloop_cfg.HsTiaCfg.DiodeClose = bFALSE;
+  hsloop_cfg.HsTiaCfg.HstiaBias = HSTIABIAS_VZERO0;
+  hsloop_cfg.HsTiaCfg.HstiaCtia = 8;
+  hsloop_cfg.HsTiaCfg.HstiaDeRload = HSTIADERLOAD_OPEN;
+  hsloop_cfg.HsTiaCfg.HstiaDeRtia = HSTIADERTIA_OPEN;
+  hsloop_cfg.HsTiaCfg.HstiaDe1Rload = HSTIADERLOAD_OPEN;
+  hsloop_cfg.HsTiaCfg.HstiaDe1Rtia = HSTIADERTIA_OPEN;
+  hsloop_cfg.HsTiaCfg.HstiaRtiaSel = HSTIARTIA_200;
+  hsloop_cfg.SWMatCfg.Dswitch = SWD_RCAL0;
+  hsloop_cfg.SWMatCfg.Pswitch = SWP_RCAL0;
+  hsloop_cfg.SWMatCfg.Nswitch = SWN_RCAL1;
+  hsloop_cfg.SWMatCfg.Tswitch = SWT_TRTIA|SWT_RCAL1;
+  hsloop_cfg.WgCfg.GainCalEn = bTRUE;
+  hsloop_cfg.WgCfg.OffsetCalEn = bTRUE;
+  hsloop_cfg.WgCfg.WgType = WGTYPE_MMR;
+  hsloop_cfg.WgCfg.WgCode = HSDACCode;
+  AD5940_HSLoopCfgS(&hsloop_cfg);
+  /* Step0.4 Turn ON reference and ADC power, and DAC power and DAC reference. We use DAC 1.8V reference to calibrate ADC. */
+  AD5940_AFECtrlS(AFECTRL_ALL, bFALSE); /* Disable all */
+  AD5940_AFECtrlS(AFECTRL_ADCPWR|AFECTRL_HPREFPWR|AFECTRL_DACREFPWR|AFECTRL_HSDACPWR|AFECTRL_SINC2NOTCH|\
+    AFECTRL_EXTBUFPWR|AFECTRL_INAMPPWR|AFECTRL_HSTIAPWR|AFECTRL_WG, bTRUE);
+  AD5940_Delay10us(25);   /* Wait 250us for reference power up */
+  /* Step0.5 INTC configure and open calibration lock */
+  AD5940_INTCCfg(AFEINTC_1, AFEINTSRC_SINC2RDY, bTRUE); /* Enable SINC2 Interrupt in INTC1 */
+  AD5940_WriteReg(REG_AFE_CALDATLOCK, KEY_CALDATLOCK);  /* Unlock KEY */
+	/* Reset Offset register before calibration */
+	AD5940_WriteReg(regaddr_offset, 0);
+	/* Update HSDACDAT after resetting calibration register */
+	AD5940_WriteReg(REG_AFE_HSDACDAT, 0x800);
+  /* Step1: Do offset calibration. */
+  {
+    int32_t ExpectedCode = 0x8000;        /* Ideal ADC output */
+    AD5940_Delay10us(10);
+    time_out = 1000;   /* Reset time out counter */
+    ADCCode = __AD5940_TakeMeasurement(&time_out);
+#ifdef ADI_DEBUG
+    ADI_Print("Voltage before cal: %f \n", AD5940_ADCCode2Volt(ADCCode, ADCPGA_Sel, 1.82));
+#endif
+
+    if(time_out == 0) goto DACCALERROR_TIMEOUT;  /* Time out error. */
+    ADCCode = ADCCode - ExpectedCode;
+    ADCCode = (((ADCCode)*LEB_Denominator)/LSB_Numerator); 
+    if(ADCCode>0)
+      ADCCode = 0xFFF - ADCCode;
+    else
+      ADCCode = -ADCCode;
+    AD5940_WriteReg(regaddr_offset, ADCCode);
+    AD5940_Delay10us(10);
+    AD5940_WriteReg(REG_AFE_HSDACDAT, 0x800);
+    AD5940_Delay10us(10);
+#ifdef ADI_DEBUG
+		ADCCode = __AD5940_TakeMeasurement(&time_out);
+		ADI_Print("Voltage after cal: %f \n", AD5940_ADCCode2Volt(ADCCode, ADCPGA_Sel, 1.82));
+#endif
+  }
+  AD5940_WriteReg(REG_AFE_CALDATLOCK, 0);  /* Lock KEY */
+  return AD5940ERR_OK;
+DACCALERROR_TIMEOUT:
+  AD5940_ADCConvtCtrlS(bFALSE);  /* Stop conversion */
+  AD5940_WriteReg(REG_AFE_CALDATLOCK, 0);  /* Lock KEY */
+  return AD5940ERR_TIMEOUT;
+}
+
+/**
+ * @brief Use ADC to measure LPDAC offset and gain factor.
+ * @note Assume ADC is accurate enough or accurate than LPDAC at least.
+ * @param pCalCfg: pointer to structure.
+ * @param pResult: the pointer to save calibration result.
+ * @return AD5940ERR_OK if succeed.
+**/
+AD5940Err AD5940_LPDACCal(LPDACCal_Type *pCalCfg, LPDACPara_Type *pResult)
+{
+  AD5940Err error = AD5940ERR_OK;
+  LPDACCfg_Type LpDacCfg;
+  ADCBaseCfg_Type adc_base;
+  ADCFilterCfg_Type adc_filter;
+
+  int32_t time_out;
+  uint32_t INTCCfg;
+  int32_t ADCCode, ADCCodeVref1p1;
+  BoolFlag bADCClk32MHzMode;
+  
+  if(pCalCfg == NULL) return AD5940ERR_NULLP; 
+  if(pResult == NULL) return AD5940ERR_NULLP;  
+  if(pCalCfg->AdcClkFreq > (32000000*0.8))
+    bADCClk32MHzMode = bTRUE;
+
+  /* Step0: Do initialization */
+  /* Turn on AD5940 references in case it's disabled. */
+  __AD5940_ReferenceON();
+  LpDacCfg.LpdacSel = pCalCfg->LpdacSel;
+  LpDacCfg.DacData12Bit = 0;
+  LpDacCfg.DacData6Bit = 0;  
+  LpDacCfg.DataRst = bFALSE;
+  LpDacCfg.LpDacRef = LPDACREF_2P5;
+  LpDacCfg.LpDacSrc = LPDACSRC_MMR;
+  LpDacCfg.LpDacSW = LPDACSW_VBIAS2PIN|LPDACSW_VZERO2PIN;
+  LpDacCfg.LpDacVbiasMux = LPDACVBIAS_12BIT;
+  LpDacCfg.LpDacVzeroMux = LPDACVZERO_6BIT;
+  LpDacCfg.PowerEn = bTRUE;
+  AD5940_LPDACCfgS(&LpDacCfg);
+
+  /* Initialize ADC filters ADCRawData-->SINC3-->SINC2+NOTCH. Use SIN2 data for calibration-->Lower noise */
+  adc_filter.ADCSinc3Osr = pCalCfg->ADCSinc3Osr;
+  adc_filter.ADCSinc2Osr = pCalCfg->ADCSinc2Osr;  /* 800KSPS/4/1333 = 150SPS */
+  adc_filter.ADCAvgNum = ADCAVGNUM_2;               /* Don't care about it. Average function is only used for DFT */
+  adc_filter.ADCRate = bADCClk32MHzMode?ADCRATE_1P6MHZ:ADCRATE_800KHZ;        /* If ADC clock is 32MHz, then set it to ADCRATE_1P6MHZ. Default is 16MHz, use ADCRATE_800KHZ. */
+  adc_filter.BpNotch = bTRUE;                       /* SINC2+Notch is one block, when bypass notch filter, we can get fresh data from SINC2 filter. */
+  adc_filter.BpSinc3 = bFALSE;                      /* We use SINC3 filter. */
+  adc_filter.Sinc2NotchEnable = bTRUE;              /* Enable the SINC2+Notch block. You can also use function AD5940_AFECtrlS */
+  AD5940_ADCFilterCfgS(&adc_filter);
+  /* Initialize ADC MUx and PGA */
+  adc_base.ADCMuxP = ADCMUXP_AGND;
+  adc_base.ADCMuxN = ADCMUXN_VSET1P1;
+  adc_base.ADCPga = ADCPGA_1;
+  AD5940_ADCBaseCfgS(&adc_base);
+  /* Turn ON ADC and its reference. And SINC2. */
+  AD5940_AFECtrlS(AFECTRL_ALL, bFALSE); /* Disable all firstly, we only enable things we use */
+  AD5940_AFECtrlS(AFECTRL_ADCPWR|AFECTRL_HPREFPWR|AFECTRL_SINC2NOTCH, bTRUE);
+  AD5940_Delay10us(25);                     /* Wait 250us for reference power up */
+  /* INTC configure and open calibration lock */
+  INTCCfg = AD5940_INTCGetCfg(AFEINTC_1);
+  AD5940_INTCCfg(AFEINTC_1, AFEINTSRC_SINC2RDY, bTRUE); /* Enable SINC2 Interrupt in INTC1 */
+  /* Step1: Measure internal 1.1V reference. */
+  {
+    //AD5940_ADCMuxCfgS(ADCMUXP_AGND, ADCMUXN_VSET1P1);
+    time_out = pCalCfg->TimeOut10us;   /* Reset time out counter */
+    ADCCodeVref1p1 = __AD5940_TakeMeasurement(&time_out);  /* Turn on ADC to get one valid data and then turn off ADC. */
+    if(time_out == 0)
+    {
+      error = AD5940ERR_TIMEOUT;
+      goto LPDACCALERROR;
+    }  /* Time out error. */
+    /* Equation1: ADCCodeVref1p1 = AGND - Vref1p1 */
+  }
+  /* Step2: Do offset measurement. */
+  {
+    /* Equation2': ADCCode = Vbias0/1 - Vref1p1 */
+    AD5940_LPDACWriteS(0,0);  /* Set LPDAC output voltage to 0.2V(zero code) */
+    if(pCalCfg->SettleTime10us > 0)
+      AD5940_Delay10us(pCalCfg->SettleTime10us);  /* Delay nx10us */
+    if(pCalCfg->LpdacSel == LPDAC0)
+      AD5940_ADCMuxCfgS(ADCMUXP_VBIAS0, ADCMUXN_VREF1P1); /* Vbias0 is routed to 12BIT LPDAC */
+    else
+      AD5940_ADCMuxCfgS(ADCMUXP_VBIAS1, ADCMUXN_VREF1P1); /* Vbias1 is routed to 12BIT LPDAC */
+
+    AD5940_Delay10us(5);  /* Delay 50us */
+    time_out = pCalCfg->TimeOut10us;   /* Reset time out counter */
+    ADCCode = __AD5940_TakeMeasurement(&time_out);  /* Turn on ADC to get one valid data and then turn off ADC. */
+    if(time_out == 0)
+    {
+      error = AD5940ERR_TIMEOUT;
+      goto LPDACCALERROR;
+    }  /* Time out error. */
+    /* Calculate the offset voltage using Equation2 - Equation1 */
+    ADCCode -= ADCCodeVref1p1;  /* Get the code of Vbias0-AGND. Then calculate the offset voltage in mV. */
+    pResult->bC2V_DAC12B = ADCCode*pCalCfg->ADCRefVolt*1e3f/32768*1.835f/1.82f; /*mV unit*/
+    /* Measure 6BIT DAC output(Vzero0/1) */
+    if(pCalCfg->LpdacSel == LPDAC0)
+      AD5940_ADCMuxCfgS(ADCMUXP_VZERO0, ADCMUXN_VREF1P1); /* Vbias0 is routed to 12BIT LPDAC */
+    else
+      AD5940_ADCMuxCfgS(ADCMUXP_VZERO1, ADCMUXN_VREF1P1); /* Vbias1 is routed to 12BIT LPDAC */
+    AD5940_Delay10us(5);  /* Delay 50us */
+    time_out = pCalCfg->TimeOut10us;   /* Reset time out counter */
+    ADCCode = __AD5940_TakeMeasurement(&time_out);  /* Turn on ADC to get one valid data and then turn off ADC. */
+    if(time_out == 0)
+    {
+      error = AD5940ERR_TIMEOUT;
+      goto LPDACCALERROR;
+    }  /* Time out error. */
+    /* Calculate the offset voltage */
+    ADCCode -= ADCCodeVref1p1;  /* Get the code of Vbias0-AGND. Then calculate the offset voltage in mV. */
+    pResult->bC2V_DAC6B = ADCCode*pCalCfg->ADCRefVolt*1e3f/32768*1.835f/1.82f; /*mV unit*/
+  }
+  /* Step3: Do gain measurement */
+  {
+    /* Equation2: ADCCode = Vbias0 - Vref1p1 */
+    AD5940_LPDACWriteS(0xfff,0x3f);  /* Set LPDAC output voltage to 2.4V(zero code) */
+    if(pCalCfg->SettleTime10us > 0)
+      AD5940_Delay10us(pCalCfg->SettleTime10us);  /* Delay nx10us */
+    if(pCalCfg->LpdacSel == LPDAC0)
+      AD5940_ADCMuxCfgS(ADCMUXP_VBIAS0, ADCMUXN_VREF1P1); /* Vbias0 is routed to 12BIT LPDAC */
+    else
+      AD5940_ADCMuxCfgS(ADCMUXP_VBIAS1, ADCMUXN_VREF1P1); /* Vbias1 is routed to 12BIT LPDAC */
+    AD5940_Delay10us(5);  /* Delay 50us */
+    time_out = pCalCfg->TimeOut10us;   /* Reset time out counter */
+    ADCCode = __AD5940_TakeMeasurement(&time_out);  /* Turn on ADC to get one valid data and then turn off ADC. */
+    if(time_out == 0)
+    {
+      error = AD5940ERR_TIMEOUT;
+      goto LPDACCALERROR;
+    }  /* Time out error. */
+    /* Calculate the offset voltage */
+    ADCCode -= ADCCodeVref1p1;  /* Get the code of Vbias0-AGND. Then calculate the gain factor 'k'. */
+    pResult->kC2V_DAC12B = (ADCCode*pCalCfg->ADCRefVolt*1e3f/32768*1.835f/1.82f - pResult->bC2V_DAC12B)/0xfff;/*mV unit*/
+    /* Measure 6BIT DAC output(Vzero0) */
+    if(pCalCfg->LpdacSel == LPDAC0)
+      AD5940_ADCMuxCfgS(ADCMUXP_VZERO0, ADCMUXN_VREF1P1); /* Vbias0 is routed to 12BIT LPDAC */
+    else
+      AD5940_ADCMuxCfgS(ADCMUXP_VZERO1, ADCMUXN_VREF1P1); /* Vbias1 is routed to 12BIT LPDAC */
+    AD5940_Delay10us(5);  /* Delay 50us */
+    time_out = pCalCfg->TimeOut10us;   /* Reset time out counter */
+    ADCCode = __AD5940_TakeMeasurement(&time_out);  /* Turn on ADC to get one valid data and then turn off ADC. */
+    if(time_out == 0)
+    {
+      error = AD5940ERR_TIMEOUT;
+      goto LPDACCALERROR;
+    }  /* Time out error. */
+    /* Calculate the offset voltage */
+    ADCCode -= ADCCodeVref1p1;  /* Get the code of Vbias0-AGND. Then calculate the offset voltage in mV. */
+    pResult->kC2V_DAC6B = (ADCCode*pCalCfg->ADCRefVolt*1e3f/32768*1.835f/1.82f - pResult->bC2V_DAC6B)/0x3f;/*mV unit*/
+  }
+  /* Step4: calculate the parameters for voltage to code calculation. */
+  pResult->kV2C_DAC12B = 1/pResult->kC2V_DAC12B;
+  pResult->bV2C_DAC12B = -pResult->bC2V_DAC12B/pResult->kC2V_DAC12B;
+  pResult->kV2C_DAC6B = 1/pResult->kC2V_DAC6B;
+  pResult->bV2C_DAC6B = -pResult->bC2V_DAC6B/pResult->kC2V_DAC6B;
+  /* Restore INTC1 SINC2 configure */
+  if(INTCCfg&AFEINTSRC_SINC2RDY);
+  else
+    AD5940_INTCCfg(AFEINTC_1, AFEINTSRC_SINC2RDY, bFALSE); /* Disable SINC2 Interrupt */
+  /* Done */
+  return AD5940ERR_OK;
+
+LPDACCALERROR:
+  AD5940_ADCConvtCtrlS(bFALSE);  /* Stop conversion */
+  return error;
+}
+
+/**
+ * @brief Use system clock to measure LFOSC frequency.
+ * @note Set system clock to external crystal to get a better measurement accuracy.
+ *       This function use 3 sequences and the start address is specified by parameter.
+ * @param pCfg: pointer to structure.
+ * @param pFreq:  Pointer to a variable that used to store frequency in Hz. 
+ * @return AD5940ERR_OK if succeed.
+**/
+AD5940Err AD5940_LFOSCMeasure(LFOSCMeasure_Type *pCfg, float *pFreq) /* Measure current LFOSC frequency. */
+{
+  /**
+   * @code
+   *  Sleep wakeup timer running...
+   *  -SLP----WKP----SLP----WKP----SLP----WKP
+   *  --|-----|-------------|-------------|------------Trigger sequencer when Wakeup Timer over.
+   *  --------|SEQA---------|SEQB----------------------Execute SeqA then SeqB
+   *  ---------|InitT--------|StopT--------------------SeqA start timer and SeqB trigger interrupt so MCU read back current count
+   *  ------------------------|INT---------------------
+   *  -----------------------------------------|Read---We read SEQTIMEOUT register here
+   *  ---------|-----TimerCount----------------|-------
+   *  ---------|--------------|---TimerCount2--|-------We change SeqB to reset timer so we measure how much time needed for MCU to read back SEQTIMEOUT register(TimerCount2)
+   * @endcode
+   * **/
+  uint32_t TimerCount, TimerCount2;
+  SEQCfg_Type seq_cfg, seq_cfg_backup;
+  SEQInfo_Type seqinfo;
+  WUPTCfg_Type wupt_cfg;
+  uint32_t INTCCfg;
+  uint32_t WuptPeriod;
+
+  static const uint32_t SeqA[]=
+  {
+    SEQ_TOUT(0x3fffffff),   /* Set time-out timer. It will always run until disable Sequencer by SPI interface. */
+  };
+  static const uint32_t SeqB[]=
+  {
+    /**
+     * Interrupt flag AFEINTSRC_ENDSEQ will be set after this command. So We can inform MCU to read back 
+     * current timer value. MCU will need some additional time to read back time count.
+     * So we use SeqB to measure how much time needed for MCU to read back 
+     * */
+    SEQ_STOP(),             
+  };
+  static const uint32_t SeqBB[]=
+  {
+    SEQ_TOUT(0x3fffffff),   /* Re-Set time-out timer, so we can measure the time needed for MCU to read out Timer Count register. */
+    SEQ_STOP(),             /* Interrupt flag AFEINTSRC_ENDSEQ will be set here */
+  };
+
+  if(pCfg == NULL) return AD5940ERR_NULLP;
+  if(pFreq == NULL) return AD5940ERR_NULLP;
+  if(pCfg->CalDuration < 1.0f)
+    return AD5940ERR_PARA;
+  AD5940_SEQGetCfg(&seq_cfg_backup);
+  INTCCfg = AD5940_INTCGetCfg(AFEINTC_1);
+  AD5940_INTCCfg(AFEINTC_1, AFEINTSRC_ENDSEQ, bTRUE);
+	AD5940_INTCClrFlag(AFEINTSRC_ALLINT);
+
+  seq_cfg.SeqMemSize = SEQMEMSIZE_2KB;  /* 2kB SRAM is used for sequencer */
+  seq_cfg.SeqBreakEn = bFALSE;
+  seq_cfg.SeqIgnoreEn = bFALSE;
+  seq_cfg.SeqCntCRCClr = bFALSE;
+  seq_cfg.SeqEnable = bTRUE;
+  seq_cfg.SeqWrTimer = 0;
+  AD5940_SEQCfg(&seq_cfg);          /* Enable sequencer */
+  
+  seqinfo.pSeqCmd = SeqA;
+  seqinfo.SeqId = SEQID_0;
+  seqinfo.SeqLen = SEQ_LEN(SeqA);
+  seqinfo.SeqRamAddr = pCfg->CalSeqAddr;
+  seqinfo.WriteSRAM = bTRUE;
+  AD5940_SEQInfoCfg(&seqinfo);
+  seqinfo.SeqId = SEQID_1;
+  seqinfo.SeqRamAddr = pCfg->CalSeqAddr + SEQ_LEN(SeqA) ;
+  seqinfo.SeqLen = SEQ_LEN(SeqB);
+  seqinfo.pSeqCmd = SeqB;
+  AD5940_SEQInfoCfg(&seqinfo);      /* Configure sequence0 and sequence1 with command SeqA and SeqB */
+	
+  wupt_cfg.WuptEn = bFALSE;
+  wupt_cfg.WuptOrder[0] = SEQID_0;
+  wupt_cfg.WuptOrder[1] = SEQID_1;
+  wupt_cfg.WuptEndSeq = WUPTENDSEQ_B;
+  wupt_cfg.SeqxWakeupTime[0] = 4;       /* Don't care. >4 is acceptable */
+  wupt_cfg.SeqxSleepTime[0] = (uint32_t)((pCfg->CalDuration)*32 + 0.5f) - 1 - 4;
+  wupt_cfg.SeqxWakeupTime[1] = 4-1;
+  wupt_cfg.SeqxSleepTime[1] = 0xffffffff; /* Don't care */
+  WuptPeriod = (wupt_cfg.SeqxSleepTime[0]+1) + (wupt_cfg.SeqxWakeupTime[1]+1);
+  AD5940_WUPTCfg(&wupt_cfg);
+  
+  AD5940_INTCClrFlag(AFEINTSRC_ENDSEQ);
+  AD5940_WUPTCtrl(bTRUE);
+  
+  while(AD5940_INTCTestFlag(AFEINTC_1, AFEINTSRC_ENDSEQ) == bFALSE);
+  TimerCount = AD5940_SEQTimeOutRd();
+  
+  AD5940_WUPTCtrl(bFALSE);
+	AD5940_WUPTTime(SEQID_0, 4, 4);	/* Set it to minimum value because we don't care about sequence0 now. We only want to measure how much time MCU will need to read register */
+  seqinfo.SeqId = SEQID_1;
+  seqinfo.SeqRamAddr = pCfg->CalSeqAddr + SEQ_LEN(SeqA) ;
+  seqinfo.SeqLen = SEQ_LEN(SeqBB);
+  seqinfo.pSeqCmd = SeqBB;
+  seqinfo.WriteSRAM = bTRUE;
+  AD5940_SEQInfoCfg(&seqinfo);
+  AD5940_SEQCtrlS(bTRUE); /* Enable Sequencer again */
+
+  AD5940_INTCClrFlag(AFEINTSRC_ENDSEQ);
+  AD5940_WUPTCtrl(bTRUE);
+  while(AD5940_INTCTestFlag(AFEINTC_1, AFEINTSRC_ENDSEQ) == bFALSE);
+  TimerCount2 = AD5940_SEQTimeOutRd();
+	AD5940_INTCTestFlag(AFEINTC_0, AFEINTSRC_ENDSEQ);
+
+  AD5940_WUPTCtrl(bFALSE);
+  AD5940_SEQCfg(&seq_cfg_backup);          /* restore sequencer configuration */
+  AD5940_INTCCfg(AFEINTC_1, AFEINTSRC_ENDSEQ, (INTCCfg&AFEINTSRC_ENDSEQ)?bTRUE:bFALSE); /* Restore interrupt configuration */
+  AD5940_INTCClrFlag(AFEINTSRC_ENDSEQ);
+  //printf("Time duration:%d ", (TimerCount2 - TimerCount));
+	*pFreq = pCfg->SystemClkFreq*WuptPeriod/(TimerCount2 - TimerCount);
+  return AD5940ERR_OK;
+}
+
+/**
+ * @} Calibration
+ * @} Calibration_Block
+*/
+
+/**
+ * @} AD5940_Functions
+ * @} AD5940_Library
+*/

--- a/examples/AD5940_BATImpedance/ad5940.h
+++ b/examples/AD5940_BATImpedance/ad5940.h
@@ -1,0 +1,4933 @@
+/**  
+ * @file       ad5940.h
+ * @brief      AD5940 library. This file contains all AD5940 library functions. 
+ * @author     ADI
+ * @date       March 2019
+ * @par Revision History:
+ * 
+ * Copyright (c) 2017-2019 Analog Devices, Inc. All Rights Reserved.
+ * 
+ * This software is proprietary to Analog Devices, Inc. and its licensors.
+ * By using this software you agree to the terms of the associated
+ * Analog Devices Software License Agreement.
+**/
+#ifndef _AD5940_H_
+#define _AD5940_H_
+#include "math.h"
+#include "string.h"
+#include "stdio.h"
+/** @addtogroup AD5940_Library
+  * @{
+  */
+
+/** 
+ * Select the correct chip.
+ * Recommend to define this in your compiler.
+ * */
+//#define CHIPSEL_M355      /**< ADuCM355 */
+//#define CHIPSEL_594X      /**< AD5940 or AD5941 */
+
+/* library version number */
+#define AD5940LIB_VER_MAJOR       0    /**< Major number */
+#define AD5940LIB_VER_MINOR       2    /**< Minor number */
+#define AD5940LIB_VER_PATCH       1    /**< Path number */
+#define AD5940LIB_VER   (AD5940LIB_VER_MAJOR<<16)|(AD5940LIB_VER_MINOR<<8)|(AD5940LIB_VER_PATCH)
+
+//#define ADI_DEBUG   /**< Comment this line to remove debug info. */
+
+#ifdef ADI_DEBUG
+#define ADI_Print printf   /**< Select the method to print out debug message */
+#endif
+
+#if defined(CHIPSEL_M355) && defined(CHIPSEL_594X)
+#error Please select the correct chip by define CHIPSEL_M355 or CHIPSEL_594X.
+#endif
+
+#if !defined(CHIPSEL_M355) && !defined(CHIPSEL_594X)
+#error Please select the correct chip by define CHIPSEL_M355 or CHIPSEL_594X.
+#endif
+
+/** 
+ * @cond
+ * @defgroup AD5940RegistersBitfields
+ * @brief All AD5940 registers and bitfields definition.
+ * @{
+*/
+//#if defined(_LANGUAGE_C) || (defined(__GNUC__) && !defined(__ASSEMBLER__))
+#include <stdint.h>
+//#endif /* _LANGUAGE_C */
+
+#ifndef __ADI_GENERATED_DEF_HEADERS__
+#define __ADI_GENERATED_DEF_HEADERS__    1
+#endif
+
+#define __ADI_HAS_AGPIO__          1
+#define __ADI_HAS_ALLON__          1
+#define __ADI_HAS_INTC__           1
+#define __ADI_HAS_AFECON__         1
+#define __ADI_HAS_WUPTMR__         1
+#define __ADI_HAS_AFE__            1
+
+/* ============================================================================================================================
+        GPIO
+   ============================================================================================================================ */
+
+/* ============================================================================================================================
+        AGPIO
+   ============================================================================================================================ */
+#define REG_AGPIO_GP0CON_RESET               0x00000000            /*      Reset Value for GP0CON  */
+#define REG_AGPIO_GP0CON                     0x00000000            /*  AGPIO GPIO Port 0 Configuration */
+#define REG_AGPIO_GP0OEN_RESET               0x00000000            /*      Reset Value for GP0OEN  */
+#define REG_AGPIO_GP0OEN                     0x00000004            /*  AGPIO GPIO Port 0 Output Enable */
+#define REG_AGPIO_GP0PE_RESET                0x00000000            /*      Reset Value for GP0PE  */
+#define REG_AGPIO_GP0PE                      0x00000008            /*  AGPIO GPIO Port 0 Pullup/Pulldown Enable */
+#define REG_AGPIO_GP0IEN_RESET               0x00000000            /*      Reset Value for GP0IEN  */
+#define REG_AGPIO_GP0IEN                     0x0000000C            /*  AGPIO GPIO Port 0 Input Path Enable */
+#define REG_AGPIO_GP0IN_RESET                0x00000000            /*      Reset Value for GP0IN  */
+#define REG_AGPIO_GP0IN                      0x00000010            /*  AGPIO GPIO Port 0 Registered Data Input */
+#define REG_AGPIO_GP0OUT_RESET               0x00000000            /*      Reset Value for GP0OUT  */
+#define REG_AGPIO_GP0OUT                     0x00000014            /*  AGPIO GPIO Port 0 Data Output */
+#define REG_AGPIO_GP0SET_RESET               0x00000000            /*      Reset Value for GP0SET  */
+#define REG_AGPIO_GP0SET                     0x00000018            /*  AGPIO GPIO Port 0 Data Out Set */
+#define REG_AGPIO_GP0CLR_RESET               0x00000000            /*      Reset Value for GP0CLR  */
+#define REG_AGPIO_GP0CLR                     0x0000001C            /*  AGPIO GPIO Port 0 Data Out Clear */
+#define REG_AGPIO_GP0TGL_RESET               0x00000000            /*      Reset Value for GP0TGL  */
+#define REG_AGPIO_GP0TGL                     0x00000020            /*  AGPIO GPIO Port 0 Pin Toggle */
+
+/* ============================================================================================================================
+        AGPIO Register BitMasks, Positions & Enumerations 
+   ============================================================================================================================ */
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPIO_GP0CON                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPIO_GP0CON_PIN7CFG            14            /*  P0.7 Configuration Bits */
+#define BITP_AGPIO_GP0CON_PIN6CFG            12            /*  P0.6 Configuration Bits */
+#define BITP_AGPIO_GP0CON_PIN5CFG            10            /*  P0.5 Configuration Bits */
+#define BITP_AGPIO_GP0CON_PIN4CFG             8            /*  P0.4 Configuration Bits */
+#define BITP_AGPIO_GP0CON_PIN3CFG             6            /*  P0.3 Configuration Bits */
+#define BITP_AGPIO_GP0CON_PIN2CFG             4            /*  P0.2 Configuration Bits */
+#define BITP_AGPIO_GP0CON_PIN1CFG             2            /*  P0.1 Configuration Bits */
+#define BITP_AGPIO_GP0CON_PIN0CFG             0            /*  P0.0 Configuration Bits */
+#define BITM_AGPIO_GP0CON_PIN7CFG            0x0000C000    /*  P0.7 Configuration Bits */
+#define BITM_AGPIO_GP0CON_PIN6CFG            0x00003000    /*  P0.6 Configuration Bits */
+#define BITM_AGPIO_GP0CON_PIN5CFG            0x00000C00    /*  P0.5 Configuration Bits */
+#define BITM_AGPIO_GP0CON_PIN4CFG            0x00000300    /*  P0.4 Configuration Bits */
+#define BITM_AGPIO_GP0CON_PIN3CFG            0x000000C0    /*  P0.3 Configuration Bits */
+#define BITM_AGPIO_GP0CON_PIN2CFG            0x00000030    /*  P0.2 Configuration Bits */
+#define BITM_AGPIO_GP0CON_PIN1CFG            0x0000000C    /*  P0.1 Configuration Bits */
+#define BITM_AGPIO_GP0CON_PIN0CFG            0x00000003    /*  P0.0 Configuration Bits */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPIO_GP0OEN                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPIO_GP0OEN_OEN                 0            /*  Pin Output Drive Enable */
+#define BITM_AGPIO_GP0OEN_OEN                0x000000FF    /*  Pin Output Drive Enable */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPIO_GP0PE                          Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPIO_GP0PE_PE                   0            /*  Pin Pull Enable */
+#define BITM_AGPIO_GP0PE_PE                  0x000000FF    /*  Pin Pull Enable */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPIO_GP0IEN                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPIO_GP0IEN_IEN                 0            /*  Input Path Enable */
+#define BITM_AGPIO_GP0IEN_IEN                0x000000FF    /*  Input Path Enable */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPIO_GP0IN                          Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPIO_GP0IN_IN                   0            /*  Registered Data Input */
+#define BITM_AGPIO_GP0IN_IN                  0x000000FF    /*  Registered Data Input */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPIO_GP0OUT                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPIO_GP0OUT_OUT                 0            /*  Data Out */
+#define BITM_AGPIO_GP0OUT_OUT                0x000000FF    /*  Data Out */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPIO_GP0SET                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPIO_GP0SET_SET                 0            /*  Set the Output HIGH */
+#define BITM_AGPIO_GP0SET_SET                0x000000FF    /*  Set the Output HIGH */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPIO_GP0CLR                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPIO_GP0CLR_CLR                 0            /*  Set the Output LOW */
+#define BITM_AGPIO_GP0CLR_CLR                0x000000FF    /*  Set the Output LOW */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPIO_GP0TGL                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPIO_GP0TGL_TGL                 0            /*  Toggle the Output */
+#define BITM_AGPIO_GP0TGL_TGL                0x000000FF    /*  Toggle the Output */
+
+
+/* ============================================================================================================================
+        
+   ============================================================================================================================ */
+
+/* ============================================================================================================================
+        AFECON
+   ============================================================================================================================ */
+#define REG_AFECON_ADIID_RESET               0x00000000            /*      Reset Value for ADIID  */
+#define REG_AFECON_ADIID                     0x00000400            /*  AFECON ADI Identification */
+#define REG_AFECON_CHIPID_RESET              0x00000000            /*      Reset Value for CHIPID  */
+#define REG_AFECON_CHIPID                    0x00000404            /*  AFECON Chip Identification */
+#define REG_AFECON_CLKCON0_RESET             0x00000441            /*      Reset Value for CLKCON0  */
+#define REG_AFECON_CLKCON0                   0x00000408            /*  AFECON Clock Divider Configuration */
+#define REG_AFECON_CLKEN1_RESET              0x000002C0            /*      Reset Value for CLKEN1  */
+#define REG_AFECON_CLKEN1                    0x00000410            /*  AFECON Clock Gate Enable */
+#define REG_AFECON_CLKSEL_RESET              0x00000000            /*      Reset Value for CLKSEL  */
+#define REG_AFECON_CLKSEL                    0x00000414            /*  AFECON Clock Select */
+#define REG_AFECON_CLKCON0KEY_RESET          0x00000000            /*      Reset Value for CLKCON0KEY  */
+#define REG_AFECON_CLKCON0KEY                0x00000420            /*  AFECON Enable Clock Division to 8Mhz,4Mhz and 2Mhz */
+#define REG_AFECON_SWRSTCON_RESET            0x00000001            /*      Reset Value for SWRSTCON  */
+#define REG_AFECON_SWRSTCON                  0x00000424            /*  AFECON Software Reset */
+#define REG_AFECON_TRIGSEQ_RESET             0x00000000            /*      Reset Value for TRIGSEQ  */
+#define REG_AFECON_TRIGSEQ                   0x00000430            /*  AFECON Trigger Sequence */
+
+/* ============================================================================================================================
+        AFECON Register BitMasks, Positions & Enumerations 
+   ============================================================================================================================ */
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFECON_ADIID                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFECON_ADIID_ADIID               0            /*  ADI Identifier. */
+#define BITM_AFECON_ADIID_ADIID              0x0000FFFF    /*  ADI Identifier. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFECON_CHIPID                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFECON_CHIPID_PARTID             4            /*  Part Identifier */
+#define BITP_AFECON_CHIPID_REVISION           0            /*  Silicon Revision Number */
+#define BITM_AFECON_CHIPID_PARTID            0x0000FFF0    /*  Part Identifier */
+#define BITM_AFECON_CHIPID_REVISION          0x0000000F    /*  Silicon Revision Number */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFECON_CLKCON0                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFECON_CLKCON0_SFFTCLKDIVCNT    10            /*  SFFT Clock Divider Configuration */
+#define BITP_AFECON_CLKCON0_ADCCLKDIV         6            /*  ADC Clock Divider Configuration */
+#define BITP_AFECON_CLKCON0_SYSCLKDIV         0            /*  System Clock Divider Configuration */
+#define BITM_AFECON_CLKCON0_SFFTCLKDIVCNT    0x0000FC00    /*  SFFT Clock Divider Configuration */
+#define BITM_AFECON_CLKCON0_ADCCLKDIV        0x000003C0    /*  ADC Clock Divider Configuration */
+#define BITM_AFECON_CLKCON0_SYSCLKDIV        0x0000003F    /*  System Clock Divider Configuration */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFECON_CLKEN1                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFECON_CLKEN1_GPT1DIS            7            /*  GPT1 Clock Enable */
+#define BITP_AFECON_CLKEN1_GPT0DIS            6            /*  GPT0 Clock Enable */
+#define BITP_AFECON_CLKEN1_ACLKDIS            5            /*  ACLK Clock Enable */
+#define BITM_AFECON_CLKEN1_GPT1DIS           0x00000080    /*  GPT1 Clock Enable */
+#define BITM_AFECON_CLKEN1_GPT0DIS           0x00000040    /*  GPT0 Clock Enable */
+#define BITM_AFECON_CLKEN1_ACLKDIS           0x00000020    /*  ACLK Clock Enable */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFECON_CLKSEL                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFECON_CLKSEL_ADCCLKSEL          2            /*  Select ADC Clock Source */
+#define BITP_AFECON_CLKSEL_SYSCLKSEL          0            /*  Select System Clock Source */
+#define BITM_AFECON_CLKSEL_ADCCLKSEL         0x0000000C    /*  Select ADC Clock Source */
+#define BITM_AFECON_CLKSEL_SYSCLKSEL         0x00000003    /*  Select System Clock Source */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFECON_CLKCON0KEY                    Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFECON_CLKCON0KEY_DIVSYSCLK_ULP_EN  0            /*  Enable Clock Division to 8Mhz,4Mhz and 2Mhz */
+#define BITM_AFECON_CLKCON0KEY_DIVSYSCLK_ULP_EN 0x0000FFFF    /*  Enable Clock Division to 8Mhz,4Mhz and 2Mhz */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFECON_SWRSTCON                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFECON_SWRSTCON_SWRSTL           0            /*  Software Reset */
+#define BITM_AFECON_SWRSTCON_SWRSTL          0x0000FFFF    /*  Software Reset */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFECON_TRIGSEQ                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFECON_TRIGSEQ_TRIG3             3            /*  Trigger Sequence 3 */
+#define BITP_AFECON_TRIGSEQ_TRIG2             2            /*  Trigger Sequence 2 */
+#define BITP_AFECON_TRIGSEQ_TRIG1             1            /*  Trigger Sequence 1 */
+#define BITP_AFECON_TRIGSEQ_TRIG0             0            /*  Trigger Sequence 0 */
+#define BITM_AFECON_TRIGSEQ_TRIG3            0x00000008    /*  Trigger Sequence 3 */
+#define BITM_AFECON_TRIGSEQ_TRIG2            0x00000004    /*  Trigger Sequence 2 */
+#define BITM_AFECON_TRIGSEQ_TRIG1            0x00000002    /*  Trigger Sequence 1 */
+#define BITM_AFECON_TRIGSEQ_TRIG0            0x00000001    /*  Trigger Sequence 0 */
+
+/* ============================================================================================================================
+        AFEWDT
+   ============================================================================================================================ */
+#define REG_AFEWDT_WDTLD                     0x00000900            /*  AFEWDT Watchdog Timer Load Value */
+#define REG_AFEWDT_WDTVALS                   0x00000904            /*  AFEWDT Current Count Value */
+#define REG_AFEWDT_WDTCON                    0x00000908            /*  AFEWDT Watchdog Timer Control Register */
+#define REG_AFEWDT_WDTCLRI                   0x0000090C            /*  AFEWDT Refresh Watchdog Register */
+#define REG_AFEWDT_WDTSTA                    0x00000918            /*  AFEWDT Timer Status */
+#define REG_AFEWDT_WDTMINLD                  0x0000091C            /*  AFEWDT Minimum Load Value */
+
+/* ============================================================================================================================
+        AFEWDT Register BitMasks, Positions & Enumerations 
+   ============================================================================================================================ */
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFEWDT_WDTLD                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFEWDT_WDTLD_LOAD                0            /*  WDT Load Value */
+#define BITM_AFEWDT_WDTLD_LOAD               (_ADI_MSK_3(0x0000FFFF,0x0000FFFF, int16_t   ))    /*  WDT Load Value */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFEWDT_WDTVALS                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFEWDT_WDTVALS_CCOUNT            0            /*  Current WDT Count Value. */
+#define BITM_AFEWDT_WDTVALS_CCOUNT           (_ADI_MSK_3(0x0000FFFF,0x0000FFFF, int16_t   ))    /*  Current WDT Count Value. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFEWDT_WDTCON                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFEWDT_WDTCON_RESERVED_15_11    11            /*  RESERVED */
+#define BITP_AFEWDT_WDTCON_WDTIRQEN          10            /*  WDT Interrupt Enable */
+#define BITP_AFEWDT_WDTCON_MINLOAD_EN         9            /*  Timer Window Control */
+#define BITP_AFEWDT_WDTCON_CLKDIV2            8            /*  Clock Source */
+#define BITP_AFEWDT_WDTCON_RESERVED1_7        7            /*  Reserved */
+#define BITP_AFEWDT_WDTCON_MDE                6            /*  Timer Mode Select */
+#define BITP_AFEWDT_WDTCON_EN                 5            /*  Timer Enable */
+#define BITP_AFEWDT_WDTCON_PRE                2            /*  Prescaler. */
+#define BITP_AFEWDT_WDTCON_IRQ                1            /*  WDT Interrupt Enable */
+#define BITP_AFEWDT_WDTCON_PDSTOP             0            /*  Power Down Stop Enable */
+#define BITM_AFEWDT_WDTCON_RESERVED_15_11    (_ADI_MSK_3(0x0000F800,0x0000F800U, uint16_t  ))    /*  RESERVED */
+#define BITM_AFEWDT_WDTCON_WDTIRQEN          (_ADI_MSK_3(0x00000400,0x00000400U, uint16_t  ))    /*  WDT Interrupt Enable */
+#define BITM_AFEWDT_WDTCON_MINLOAD_EN        (_ADI_MSK_3(0x00000200,0x00000200U, uint16_t  ))    /*  Timer Window Control */
+#define BITM_AFEWDT_WDTCON_CLKDIV2           (_ADI_MSK_3(0x00000100,0x00000100U, uint16_t  ))    /*  Clock Source */
+#define BITM_AFEWDT_WDTCON_RESERVED1_7       (_ADI_MSK_3(0x00000080,0x00000080U, uint16_t  ))    /*  Reserved */
+#define BITM_AFEWDT_WDTCON_MDE               (_ADI_MSK_3(0x00000040,0x00000040U, uint16_t  ))    /*  Timer Mode Select */
+#define BITM_AFEWDT_WDTCON_EN                (_ADI_MSK_3(0x00000020,0x00000020U, uint16_t  ))    /*  Timer Enable */
+#define BITM_AFEWDT_WDTCON_PRE               (_ADI_MSK_3(0x0000000C,0x0000000CU, uint16_t  ))    /*  Prescaler. */
+#define BITM_AFEWDT_WDTCON_IRQ               (_ADI_MSK_3(0x00000002,0x00000002U, uint16_t  ))    /*  WDT Interrupt Enable */
+#define BITM_AFEWDT_WDTCON_PDSTOP            (_ADI_MSK_3(0x00000001,0x00000001U, uint16_t  ))    /*  Power Down Stop Enable */
+#define ENUM_AFEWDT_WDTCON_RESET             (_ADI_MSK_3(0x00000000,0x00000000U, uint16_t  ))    /*  IRQ: Watchdog Timer timeout creates a reset. */
+#define ENUM_AFEWDT_WDTCON_INTERRUPT         (_ADI_MSK_3(0x00000002,0x00000002U, uint16_t  ))    /*  IRQ: Watchdog Timer  timeout creates an interrupt instead of reset. */
+#define ENUM_AFEWDT_WDTCON_CONTINUE          (_ADI_MSK_3(0x00000000,0x00000000U, uint16_t  ))    /*  PDSTOP: Continue Counting When In Hibernate */
+#define ENUM_AFEWDT_WDTCON_STOP              (_ADI_MSK_3(0x00000001,0x00000001U, uint16_t  ))    /*  PDSTOP: Stop Counter When In Hibernate. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFEWDT_WDTCLRI                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFEWDT_WDTCLRI_CLRWDG            0            /*  Refresh Register */
+#define BITM_AFEWDT_WDTCLRI_CLRWDG           (_ADI_MSK_3(0x0000FFFF,0x0000FFFF, int16_t   ))    /*  Refresh Register */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFEWDT_WDTSTA                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFEWDT_WDTSTA_RESERVED_15_7      7            /*  RESERVED */
+#define BITP_AFEWDT_WDTSTA_TMINLD             6            /*  WDTMINLD Write Status */
+#define BITP_AFEWDT_WDTSTA_OTPWRDONE          5            /*  Reset Type Status */
+#define BITP_AFEWDT_WDTSTA_LOCK               4            /*  Lock Status */
+#define BITP_AFEWDT_WDTSTA_CON                3            /*  WDTCON Write Status */
+#define BITP_AFEWDT_WDTSTA_TLD                2            /*  WDTVAL Write Status */
+#define BITP_AFEWDT_WDTSTA_CLRI               1            /*  WDTCLRI Write Status */
+#define BITP_AFEWDT_WDTSTA_IRQ                0            /*  WDT Interrupt */
+#define BITM_AFEWDT_WDTSTA_RESERVED_15_7     (_ADI_MSK_3(0x0000FF80,0x0000FF80U, uint16_t  ))    /*  RESERVED */
+#define BITM_AFEWDT_WDTSTA_TMINLD            (_ADI_MSK_3(0x00000040,0x00000040U, uint16_t  ))    /*  WDTMINLD Write Status */
+#define BITM_AFEWDT_WDTSTA_OTPWRDONE         (_ADI_MSK_3(0x00000020,0x00000020U, uint16_t  ))    /*  Reset Type Status */
+#define BITM_AFEWDT_WDTSTA_LOCK              (_ADI_MSK_3(0x00000010,0x00000010U, uint16_t  ))    /*  Lock Status */
+#define BITM_AFEWDT_WDTSTA_CON               (_ADI_MSK_3(0x00000008,0x00000008U, uint16_t  ))    /*  WDTCON Write Status */
+#define BITM_AFEWDT_WDTSTA_TLD               (_ADI_MSK_3(0x00000004,0x00000004U, uint16_t  ))    /*  WDTVAL Write Status */
+#define BITM_AFEWDT_WDTSTA_CLRI              (_ADI_MSK_3(0x00000002,0x00000002U, uint16_t  ))    /*  WDTCLRI Write Status */
+#define BITM_AFEWDT_WDTSTA_IRQ               (_ADI_MSK_3(0x00000001,0x00000001U, uint16_t  ))    /*  WDT Interrupt */
+#define ENUM_AFEWDT_WDTSTA_OPEN              (_ADI_MSK_3(0x00000000,0x00000000U, uint16_t  ))    /*  LOCK: Timer Operation Not Locked */
+#define ENUM_AFEWDT_WDTSTA_LOCKED            (_ADI_MSK_3(0x00000010,0x00000010U, uint16_t  ))    /*  LOCK: Timer Enabled and Locked */
+#define ENUM_AFEWDT_WDTSTA_SYNC_COMPLETE     (_ADI_MSK_3(0x00000000,0x00000000U, uint16_t  ))    /*  TLD: Arm and AFE Watchdog Clock Domains WDTLD values match */
+#define ENUM_AFEWDT_WDTSTA_SYNC_IN_PROGRESS  (_ADI_MSK_3(0x00000004,0x00000004U, uint16_t  ))    /*  TLD: Synchronize In Progress */
+#define ENUM_AFEWDT_WDTSTA_CLEARED           (_ADI_MSK_3(0x00000000,0x00000000U, uint16_t  ))    /*  IRQ: Watchdog Timer Interrupt Not Pending */
+#define ENUM_AFEWDT_WDTSTA_PENDING           (_ADI_MSK_3(0x00000001,0x00000001U, uint16_t  ))    /*  IRQ: Watchdog Timer Interrupt Pending */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFEWDT_WDTMINLD                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFEWDT_WDTMINLD_MIN_LOAD         0            /*  WDT Min Load Value */
+#define BITM_AFEWDT_WDTMINLD_MIN_LOAD        (_ADI_MSK_3(0x0000FFFF,0x0000FFFF, int16_t   ))    /*  WDT Min Load Value */
+
+/* ============================================================================================================================
+        Wakeup Timer
+   ============================================================================================================================ */
+
+/* ============================================================================================================================
+        WUPTMR
+   ============================================================================================================================ */
+#define REG_WUPTMR_CON_RESET                 0x00000000            /*      Reset Value for CON  */
+#define REG_WUPTMR_CON                       0x00000800            /*  WUPTMR Timer Control */
+#define REG_WUPTMR_SEQORDER_RESET            0x00000000            /*      Reset Value for SEQORDER  */
+#define REG_WUPTMR_SEQORDER                  0x00000804            /*  WUPTMR Order Control */
+#define REG_WUPTMR_SEQ0WUPL_RESET            0x0000FFFF            /*      Reset Value for SEQ0WUPL  */
+#define REG_WUPTMR_SEQ0WUPL                  0x00000808            /*  WUPTMR SEQ0 WTimeL (LSB) */
+#define REG_WUPTMR_SEQ0WUPH_RESET            0x0000000F            /*      Reset Value for SEQ0WUPH  */
+#define REG_WUPTMR_SEQ0WUPH                  0x0000080C            /*  WUPTMR SEQ0 WTimeH (MSB) */
+#define REG_WUPTMR_SEQ0SLEEPL_RESET          0x0000FFFF            /*      Reset Value for SEQ0SLEEPL  */
+#define REG_WUPTMR_SEQ0SLEEPL                0x00000810            /*  WUPTMR SEQ0 STimeL (LSB) */
+#define REG_WUPTMR_SEQ0SLEEPH_RESET          0x0000000F            /*      Reset Value for SEQ0SLEEPH  */
+#define REG_WUPTMR_SEQ0SLEEPH                0x00000814            /*  WUPTMR SEQ0 STimeH (MSB) */
+#define REG_WUPTMR_SEQ1WUPL_RESET            0x0000FFFF            /*      Reset Value for SEQ1WUPL  */
+#define REG_WUPTMR_SEQ1WUPL                  0x00000818            /*  WUPTMR SEQ1 WTimeL (LSB) */
+#define REG_WUPTMR_SEQ1WUPH_RESET            0x0000000F            /*      Reset Value for SEQ1WUPH  */
+#define REG_WUPTMR_SEQ1WUPH                  0x0000081C            /*  WUPTMR SEQ1 WTimeH (MSB) */
+#define REG_WUPTMR_SEQ1SLEEPL_RESET          0x0000FFFF            /*      Reset Value for SEQ1SLEEPL  */
+#define REG_WUPTMR_SEQ1SLEEPL                0x00000820            /*  WUPTMR SEQ1 STimeL (LSB) */
+#define REG_WUPTMR_SEQ1SLEEPH_RESET          0x0000000F            /*      Reset Value for SEQ1SLEEPH  */
+#define REG_WUPTMR_SEQ1SLEEPH                0x00000824            /*  WUPTMR SEQ1 STimeH (MSB) */
+#define REG_WUPTMR_SEQ2WUPL_RESET            0x0000FFFF            /*      Reset Value for SEQ2WUPL  */
+#define REG_WUPTMR_SEQ2WUPL                  0x00000828            /*  WUPTMR SEQ2 WTimeL (LSB) */
+#define REG_WUPTMR_SEQ2WUPH_RESET            0x0000000F            /*      Reset Value for SEQ2WUPH  */
+#define REG_WUPTMR_SEQ2WUPH                  0x0000082C            /*  WUPTMR SEQ2 WTimeH (MSB) */
+#define REG_WUPTMR_SEQ2SLEEPL_RESET          0x0000FFFF            /*      Reset Value for SEQ2SLEEPL  */
+#define REG_WUPTMR_SEQ2SLEEPL                0x00000830            /*  WUPTMR SEQ2 STimeL (LSB) */
+#define REG_WUPTMR_SEQ2SLEEPH_RESET          0x0000000F            /*      Reset Value for SEQ2SLEEPH  */
+#define REG_WUPTMR_SEQ2SLEEPH                0x00000834            /*  WUPTMR SEQ2 STimeH (MSB) */
+#define REG_WUPTMR_SEQ3WUPL_RESET            0x0000FFFF            /*      Reset Value for SEQ3WUPL  */
+#define REG_WUPTMR_SEQ3WUPL                  0x00000838            /*  WUPTMR SEQ3 WTimeL (LSB) */
+#define REG_WUPTMR_SEQ3WUPH_RESET            0x0000000F            /*      Reset Value for SEQ3WUPH  */
+#define REG_WUPTMR_SEQ3WUPH                  0x0000083C            /*  WUPTMR SEQ3 WTimeH (MSB) */
+#define REG_WUPTMR_SEQ3SLEEPL_RESET          0x0000FFFF            /*      Reset Value for SEQ3SLEEPL  */
+#define REG_WUPTMR_SEQ3SLEEPL                0x00000840            /*  WUPTMR SEQ3 STimeL (LSB) */
+#define REG_WUPTMR_SEQ3SLEEPH_RESET          0x0000000F            /*      Reset Value for SEQ3SLEEPH  */
+#define REG_WUPTMR_SEQ3SLEEPH                0x00000844            /*  WUPTMR SEQ3 STimeH (MSB) */
+
+/* ============================================================================================================================
+        WUPTMR Register BitMasks, Positions & Enumerations 
+   ============================================================================================================================ */
+/* -------------------------------------------------------------------------------------------------------------------------
+          WUPTMR_CON                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_WUPTMR_CON_MSKTRG                6            /*  Mark Sequence Trigger from Sleep Wakeup Timer */
+#define BITP_WUPTMR_CON_CLKSEL                4            /*  Clock Selection */
+#define BITP_WUPTMR_CON_ENDSEQ                1            /*  End Sequence */
+#define BITP_WUPTMR_CON_EN                    0            /*  Sleep Wake Timer Enable Bit */
+#define BITM_WUPTMR_CON_MSKTRG               0x00000040    /*  Mark Sequence Trigger from Sleep Wakeup Timer */
+#define BITM_WUPTMR_CON_CLKSEL               0x00000030    /*  Clock Selection */
+#define BITM_WUPTMR_CON_ENDSEQ               0x0000000E    /*  End Sequence */
+#define BITM_WUPTMR_CON_EN                   0x00000001    /*  Sleep Wake Timer Enable Bit */
+#define ENUM_WUPTMR_CON_SWT32K0              0x00000000            /*  CLKSEL: Internal 32kHz OSC */
+#define ENUM_WUPTMR_CON_SWTEXT0              0x00000010            /*  CLKSEL: External Clock */
+#define ENUM_WUPTMR_CON_SWT32K               0x00000020            /*  CLKSEL: Internal 32kHz OSC */
+#define ENUM_WUPTMR_CON_SWTEXT               0x00000030            /*  CLKSEL: External Clock */
+#define ENUM_WUPTMR_CON_ENDSEQA              0x00000000            /*  ENDSEQ: The Sleep Wakeup Timer Will Stop At SeqA And Then Go Back To SeqA */
+#define ENUM_WUPTMR_CON_ENDSEQB              0x00000002            /*  ENDSEQ: The Sleep Wakeup Timer Will Stop At SeqB And Then Go Back To SeqA */
+#define ENUM_WUPTMR_CON_ENDSEQC              0x00000004            /*  ENDSEQ: The Sleep Wakeup Timer Will Stop At SeqC And Then Go Back To SeqA */
+#define ENUM_WUPTMR_CON_ENDSEQD              0x00000006            /*  ENDSEQ: The Sleep Wakeup Timer Will Stop At SeqD And Then Go Back To SeqA */
+#define ENUM_WUPTMR_CON_ENDSEQE              0x00000008            /*  ENDSEQ: The Sleep Wakeup Timer Will Stop At SeqE And Then Go Back To SeqA */
+#define ENUM_WUPTMR_CON_ENDSEQF              0x0000000A            /*  ENDSEQ: The Sleep Wakeup Timer Will Stop At SeqF And Then Go Back To SeqA */
+#define ENUM_WUPTMR_CON_ENDSEQG              0x0000000C            /*  ENDSEQ: The Sleep Wakeup Timer Will Stop At SeqG And Then Go Back To SeqA */
+#define ENUM_WUPTMR_CON_ENDSEQH              0x0000000E            /*  ENDSEQ: The Sleep Wakeup Timer Will Stop At SeqH And Then Go Back To SeqA */
+#define ENUM_WUPTMR_CON_SWTEN                0x00000000            /*  EN: Enable Sleep Wakeup Timer */
+#define ENUM_WUPTMR_CON_SWTDIS               0x00000001            /*  EN: Disable Sleep Wakeup Timer */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          WUPTMR_SEQORDER                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_WUPTMR_SEQORDER_SEQH            14            /*  SEQH Config */
+#define BITP_WUPTMR_SEQORDER_SEQG            12            /*  SEQG Config */
+#define BITP_WUPTMR_SEQORDER_SEQF            10            /*  SEQF Config */
+#define BITP_WUPTMR_SEQORDER_SEQE             8            /*  SEQE Config */
+#define BITP_WUPTMR_SEQORDER_SEQD             6            /*  SEQD Config */
+#define BITP_WUPTMR_SEQORDER_SEQC             4            /*  SEQC Config */
+#define BITP_WUPTMR_SEQORDER_SEQB             2            /*  SEQB Config */
+#define BITP_WUPTMR_SEQORDER_SEQA             0            /*  SEQA Config */
+#define BITM_WUPTMR_SEQORDER_SEQH            0x0000C000    /*  SEQH Config */
+#define BITM_WUPTMR_SEQORDER_SEQG            0x00003000    /*  SEQG Config */
+#define BITM_WUPTMR_SEQORDER_SEQF            0x00000C00    /*  SEQF Config */
+#define BITM_WUPTMR_SEQORDER_SEQE            0x00000300    /*  SEQE Config */
+#define BITM_WUPTMR_SEQORDER_SEQD            0x000000C0    /*  SEQD Config */
+#define BITM_WUPTMR_SEQORDER_SEQC            0x00000030    /*  SEQC Config */
+#define BITM_WUPTMR_SEQORDER_SEQB            0x0000000C    /*  SEQB Config */
+#define BITM_WUPTMR_SEQORDER_SEQA            0x00000003    /*  SEQA Config */
+#define ENUM_WUPTMR_SEQORDER_SEQH0           0x00000000            /*  SEQH: Fill SEQ0 In */
+#define ENUM_WUPTMR_SEQORDER_SEQH1           0x00004000            /*  SEQH: Fill SEQ1 In */
+#define ENUM_WUPTMR_SEQORDER_SEQH2           0x00008000            /*  SEQH: Fill SEQ2 In */
+#define ENUM_WUPTMR_SEQORDER_SEQH3           0x0000C000            /*  SEQH: Fill SEQ3 In */
+#define ENUM_WUPTMR_SEQORDER_SEQG0           0x00000000            /*  SEQG: Fill SEQ0 In */
+#define ENUM_WUPTMR_SEQORDER_SEQG1           0x00001000            /*  SEQG: Fill SEQ1 In */
+#define ENUM_WUPTMR_SEQORDER_SEQG2           0x00002000            /*  SEQG: Fill SEQ2 In */
+#define ENUM_WUPTMR_SEQORDER_SEQG3           0x00003000            /*  SEQG: Fill SEQ3 In */
+#define ENUM_WUPTMR_SEQORDER_SEQF0           0x00000000            /*  SEQF: Fill SEQ0 In */
+#define ENUM_WUPTMR_SEQORDER_SEQF1           0x00000400            /*  SEQF: Fill SEQ1 In */
+#define ENUM_WUPTMR_SEQORDER_SEQF2           0x00000800            /*  SEQF: Fill SEQ2 In */
+#define ENUM_WUPTMR_SEQORDER_SEQF3           0x00000C00            /*  SEQF: Fill SEQ3 In */
+#define ENUM_WUPTMR_SEQORDER_SEQE0           0x00000000            /*  SEQE: Fill SEQ0 In */
+#define ENUM_WUPTMR_SEQORDER_SEQE1           0x00000100            /*  SEQE: Fill SEQ1 In */
+#define ENUM_WUPTMR_SEQORDER_SEQE2           0x00000200            /*  SEQE: Fill SEQ2 In */
+#define ENUM_WUPTMR_SEQORDER_SEQE3           0x00000300            /*  SEQE: Fill SEQ3 In */
+#define ENUM_WUPTMR_SEQORDER_SEQD0           0x00000000            /*  SEQD: Fill SEQ0 In */
+#define ENUM_WUPTMR_SEQORDER_SEQD1           0x00000040            /*  SEQD: Fill SEQ1 In */
+#define ENUM_WUPTMR_SEQORDER_SEQD2           0x00000080            /*  SEQD: Fill SEQ2 In */
+#define ENUM_WUPTMR_SEQORDER_SEQD3           0x000000C0            /*  SEQD: Fill SEQ3 In */
+#define ENUM_WUPTMR_SEQORDER_SEQC0           0x00000000            /*  SEQC: Fill SEQ0 In */
+#define ENUM_WUPTMR_SEQORDER_SEQC1           0x00000010            /*  SEQC: Fill SEQ1 In */
+#define ENUM_WUPTMR_SEQORDER_SEQC2           0x00000020            /*  SEQC: Fill SEQ2 In */
+#define ENUM_WUPTMR_SEQORDER_SEQC3           0x00000030            /*  SEQC: Fill SEQ3 In */
+#define ENUM_WUPTMR_SEQORDER_SEQB0           0x00000000            /*  SEQB: Fill SEQ0 In */
+#define ENUM_WUPTMR_SEQORDER_SEQB1           0x00000004            /*  SEQB: Fill SEQ1 In */
+#define ENUM_WUPTMR_SEQORDER_SEQB2           0x00000008            /*  SEQB: Fill SEQ2 In */
+#define ENUM_WUPTMR_SEQORDER_SEQB3           0x0000000C            /*  SEQB: Fill SEQ3 In */
+#define ENUM_WUPTMR_SEQORDER_SEQA0           0x00000000            /*  SEQA: Fill SEQ0 In */
+#define ENUM_WUPTMR_SEQORDER_SEQA1           0x00000001            /*  SEQA: Fill SEQ1 In */
+#define ENUM_WUPTMR_SEQORDER_SEQA2           0x00000002            /*  SEQA: Fill SEQ2 In */
+#define ENUM_WUPTMR_SEQORDER_SEQA3           0x00000003            /*  SEQA: Fill SEQ3 In */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          WUPTMR_SEQ0WUPL                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_WUPTMR_SEQ0WUPL_WAKEUPTIME0      0            /*  Sequence 0 Sleep Period */
+#define BITM_WUPTMR_SEQ0WUPL_WAKEUPTIME0     0x0000FFFF    /*  Sequence 0 Sleep Period */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          WUPTMR_SEQ0WUPH                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_WUPTMR_SEQ0WUPH_WAKEUPTIME0      0            /*  Sequence 0 Sleep Period */
+#define BITM_WUPTMR_SEQ0WUPH_WAKEUPTIME0     0x0000000F    /*  Sequence 0 Sleep Period */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          WUPTMR_SEQ0SLEEPL                    Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_WUPTMR_SEQ0SLEEPL_SLEEPTIME0     0            /*  Sequence 0 Active Period */
+#define BITM_WUPTMR_SEQ0SLEEPL_SLEEPTIME0    0x0000FFFF    /*  Sequence 0 Active Period */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          WUPTMR_SEQ0SLEEPH                    Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_WUPTMR_SEQ0SLEEPH_SLEEPTIME0     0            /*  Sequence 0 Active Period */
+#define BITM_WUPTMR_SEQ0SLEEPH_SLEEPTIME0    0x0000000F    /*  Sequence 0 Active Period */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          WUPTMR_SEQ1WUPL                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_WUPTMR_SEQ1WUPL_WAKEUPTIME       0            /*  Sequence 1 Sleep Period */
+#define BITM_WUPTMR_SEQ1WUPL_WAKEUPTIME      0x0000FFFF    /*  Sequence 1 Sleep Period */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          WUPTMR_SEQ1WUPH                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_WUPTMR_SEQ1WUPH_WAKEUPTIME       0            /*  Sequence 1 Sleep Period */
+#define BITM_WUPTMR_SEQ1WUPH_WAKEUPTIME      0x0000000F    /*  Sequence 1 Sleep Period */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          WUPTMR_SEQ1SLEEPL                    Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_WUPTMR_SEQ1SLEEPL_SLEEPTIME1     0            /*  Sequence 1 Active Period */
+#define BITM_WUPTMR_SEQ1SLEEPL_SLEEPTIME1    0x0000FFFF    /*  Sequence 1 Active Period */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          WUPTMR_SEQ1SLEEPH                    Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_WUPTMR_SEQ1SLEEPH_SLEEPTIME1     0            /*  Sequence 1 Active Period */
+#define BITM_WUPTMR_SEQ1SLEEPH_SLEEPTIME1    0x0000000F    /*  Sequence 1 Active Period */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          WUPTMR_SEQ2WUPL                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_WUPTMR_SEQ2WUPL_WAKEUPTIME2      0            /*  Sequence 2 Sleep Period */
+#define BITM_WUPTMR_SEQ2WUPL_WAKEUPTIME2     0x0000FFFF    /*  Sequence 2 Sleep Period */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          WUPTMR_SEQ2WUPH                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_WUPTMR_SEQ2WUPH_WAKEUPTIME2      0            /*  Sequence 2 Sleep Period */
+#define BITM_WUPTMR_SEQ2WUPH_WAKEUPTIME2     0x0000000F    /*  Sequence 2 Sleep Period */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          WUPTMR_SEQ2SLEEPL                    Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_WUPTMR_SEQ2SLEEPL_SLEEPTIME2     0            /*  Sequence 2 Active Period */
+#define BITM_WUPTMR_SEQ2SLEEPL_SLEEPTIME2    0x0000FFFF    /*  Sequence 2 Active Period */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          WUPTMR_SEQ2SLEEPH                    Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_WUPTMR_SEQ2SLEEPH_SLEEPTIME2     0            /*  Sequence 2 Active Period */
+#define BITM_WUPTMR_SEQ2SLEEPH_SLEEPTIME2    0x0000000F    /*  Sequence 2 Active Period */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          WUPTMR_SEQ3WUPL                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_WUPTMR_SEQ3WUPL_WAKEUPTIME3      0            /*  Sequence 3 Sleep Period */
+#define BITM_WUPTMR_SEQ3WUPL_WAKEUPTIME3     0x0000FFFF    /*  Sequence 3 Sleep Period */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          WUPTMR_SEQ3WUPH                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_WUPTMR_SEQ3WUPH_WAKEUPTIME3      0            /*  Sequence 3 Sleep Period */
+#define BITM_WUPTMR_SEQ3WUPH_WAKEUPTIME3     0x0000000F    /*  Sequence 3 Sleep Period */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          WUPTMR_SEQ3SLEEPL                    Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_WUPTMR_SEQ3SLEEPL_SLEEPTIME3     0            /*  Sequence 3 Active Period */
+#define BITM_WUPTMR_SEQ3SLEEPL_SLEEPTIME3    0x0000FFFF    /*  Sequence 3 Active Period */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          WUPTMR_SEQ3SLEEPH                    Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_WUPTMR_SEQ3SLEEPH_SLEEPTIME3     0            /*  Sequence 3 Active Period */
+#define BITM_WUPTMR_SEQ3SLEEPH_SLEEPTIME3    0x0000000F    /*  Sequence 3 Active Period */
+
+
+/* ============================================================================================================================
+        Always On Register
+   ============================================================================================================================ */
+
+/* ============================================================================================================================
+        ALLON
+   ============================================================================================================================ */
+#define REG_ALLON_PWRMOD_RESET               0x00000001            /*      Reset Value for PWRMOD  */
+#define REG_ALLON_PWRMOD                     0x00000A00            /*  ALLON Power Modes */
+#define REG_ALLON_PWRKEY_RESET               0x00000000            /*      Reset Value for PWRKEY  */
+#define REG_ALLON_PWRKEY                     0x00000A04            /*  ALLON Key Protection for PWRMOD */
+#define REG_ALLON_OSCKEY_RESET               0x00000000            /*      Reset Value for OSCKEY  */
+#define REG_ALLON_OSCKEY                     0x00000A0C            /*  ALLON Key Protection for OSCCON */
+#define REG_ALLON_OSCCON_RESET               0x00000003            /*      Reset Value for OSCCON  */
+#define REG_ALLON_OSCCON                     0x00000A10            /*  ALLON Oscillator Control */
+#define REG_ALLON_TMRCON_RESET               0x00000000            /*      Reset Value for TMRCON  */
+#define REG_ALLON_TMRCON                     0x00000A1C            /*  ALLON Timer Wakeup Configuration */
+#define REG_ALLON_EI0CON_RESET               0x00000000            /*      Reset Value for EI0CON  */
+#define REG_ALLON_EI0CON                     0x00000A20            /*  ALLON External Interrupt Configuration 0 */
+#define REG_ALLON_EI1CON_RESET               0x00000000            /*      Reset Value for EI1CON  */
+#define REG_ALLON_EI1CON                     0x00000A24            /*  ALLON External Interrupt Configuration 1 */
+#define REG_ALLON_EI2CON_RESET               0x00000000            /*      Reset Value for EI2CON  */
+#define REG_ALLON_EI2CON                     0x00000A28            /*  ALLON External Interrupt Configuration 2 */
+#define REG_ALLON_EICLR_RESET                0x0000C000            /*      Reset Value for EICLR  */
+#define REG_ALLON_EICLR                      0x00000A30            /*  ALLON External Interrupt Clear */
+#define REG_ALLON_RSTSTA_RESET               0x00000000            /*      Reset Value for RSTSTA  */
+#define REG_ALLON_RSTSTA                     0x00000A40            /*  ALLON Reset Status */
+#define REG_ALLON_RSTCONKEY_RESET            0x00000000            /*      Reset Value for RSTCONKEY  */
+#define REG_ALLON_RSTCONKEY                  0x00000A5C            /*  ALLON Key Protection for RSTCON Register */
+#define REG_ALLON_LOSCTST_RESET              0x0000008F            /*      Reset Value for LOSCTST  */
+#define REG_ALLON_LOSCTST                    0x00000A6C            /*  ALLON Internal LF Oscillator Test */
+#define REG_ALLON_CLKEN0_RESET               0x00000004            /*      Reset Value for CLKEN0  */
+#define REG_ALLON_CLKEN0                     0x00000A70            /*  ALLON 32KHz Peripheral Clock Enable */
+
+/* ============================================================================================================================
+        ALLON Register BitMasks, Positions & Enumerations 
+   ============================================================================================================================ */
+/* -------------------------------------------------------------------------------------------------------------------------
+          ALLON_PWRMOD                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_ALLON_PWRMOD_RAMRETEN           15            /*  Retention for RAM */
+#define BITP_ALLON_PWRMOD_ADCRETEN           14            /*  Keep ADC Power Switch on in Hibernate */
+#define BITP_ALLON_PWRMOD_SEQSLPEN            3            /*  Auto Sleep by Sequencer Command */
+#define BITP_ALLON_PWRMOD_TMRSLPEN            2            /*  Auto Sleep by Sleep Wakeup Timer */
+#define BITP_ALLON_PWRMOD_PWRMOD              0            /*  Power Mode Control Bits */
+#define BITM_ALLON_PWRMOD_RAMRETEN           0x00008000    /*  Retention for RAM */
+#define BITM_ALLON_PWRMOD_ADCRETEN           0x00004000    /*  Keep ADC Power Switch on in Hibernate */
+#define BITM_ALLON_PWRMOD_SEQSLPEN           0x00000008    /*  Auto Sleep by Sequencer Command */
+#define BITM_ALLON_PWRMOD_TMRSLPEN           0x00000004    /*  Auto Sleep by Sleep Wakeup Timer */
+#define BITM_ALLON_PWRMOD_PWRMOD             0x00000003    /*  Power Mode Control Bits */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          ALLON_PWRKEY                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_ALLON_PWRKEY_PWRKEY              0            /*  PWRMOD Key Register */
+#define BITM_ALLON_PWRKEY_PWRKEY             0x0000FFFF    /*  PWRMOD Key Register */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          ALLON_OSCKEY                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_ALLON_OSCKEY_OSCKEY              0            /*  Oscillator Control Key Register. */
+#define BITM_ALLON_OSCKEY_OSCKEY             0x0000FFFF    /*  Oscillator Control Key Register. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          ALLON_OSCCON                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_ALLON_OSCCON_HFXTALOK           10            /*  Status of HFXTAL Oscillator */
+#define BITP_ALLON_OSCCON_HFOSCOK             9            /*  Status of HFOSC Oscillator */
+#define BITP_ALLON_OSCCON_LFOSCOK             8            /*  Status of LFOSC Oscillator */
+#define BITP_ALLON_OSCCON_HFXTALEN            2            /*  High Frequency Crystal Oscillator Enable */
+#define BITP_ALLON_OSCCON_HFOSCEN             1            /*  High Frequency Internal Oscillator Enable */
+#define BITP_ALLON_OSCCON_LFOSCEN             0            /*  Low Frequency Internal Oscillator Enable */
+#define BITM_ALLON_OSCCON_HFXTALOK           0x00000400    /*  Status of HFXTAL Oscillator */
+#define BITM_ALLON_OSCCON_HFOSCOK            0x00000200    /*  Status of HFOSC Oscillator */
+#define BITM_ALLON_OSCCON_LFOSCOK            0x00000100    /*  Status of LFOSC Oscillator */
+#define BITM_ALLON_OSCCON_HFXTALEN           0x00000004    /*  High Frequency Crystal Oscillator Enable */
+#define BITM_ALLON_OSCCON_HFOSCEN            0x00000002    /*  High Frequency Internal Oscillator Enable */
+#define BITM_ALLON_OSCCON_LFOSCEN            0x00000001    /*  Low Frequency Internal Oscillator Enable */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          ALLON_TMRCON                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_ALLON_TMRCON_TMRINTEN            0            /*  Enable Wakeup Timer */
+#define BITM_ALLON_TMRCON_TMRINTEN           0x00000001    /*  Enable Wakeup Timer */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          ALLON_EI0CON                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_ALLON_EI0CON_IRQ3EN             15            /*  External Interrupt 3 Enable Bit */
+#define BITP_ALLON_EI0CON_IRQ3MDE            12            /*  External Interrupt 3 Mode Registers */
+#define BITP_ALLON_EI0CON_IRQ2EN             11            /*  External Interrupt 2 Enable Bit */
+#define BITP_ALLON_EI0CON_IRQ2MDE             8            /*  External Interrupt 2 Mode Registers */
+#define BITP_ALLON_EI0CON_IRQ1EN              7            /*  External Interrupt 1 Enable Bit */
+#define BITP_ALLON_EI0CON_IRQ1MDE             4            /*  External Interrupt 1 Mode Registers */
+#define BITP_ALLON_EI0CON_IRQ0EN              3            /*  External Interrupt 0 Enable Bit */
+#define BITP_ALLON_EI0CON_IRQ0MDE             0            /*  External Interrupt 0 Mode Registers */
+#define BITM_ALLON_EI0CON_IRQ3EN             0x00008000    /*  External Interrupt 3 Enable Bit */
+#define BITM_ALLON_EI0CON_IRQ3MDE            0x00007000    /*  External Interrupt 3 Mode Registers */
+#define BITM_ALLON_EI0CON_IRQ2EN             0x00000800    /*  External Interrupt 2 Enable Bit */
+#define BITM_ALLON_EI0CON_IRQ2MDE            0x00000700    /*  External Interrupt 2 Mode Registers */
+#define BITM_ALLON_EI0CON_IRQ1EN             0x00000080    /*  External Interrupt 1 Enable Bit */
+#define BITM_ALLON_EI0CON_IRQ1MDE            0x00000070    /*  External Interrupt 1 Mode Registers */
+#define BITM_ALLON_EI0CON_IRQ0EN             0x00000008    /*  External Interrupt 0 Enable Bit */
+#define BITM_ALLON_EI0CON_IRQ0MDE            0x00000007    /*  External Interrupt 0 Mode Registers */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          ALLON_EI1CON                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_ALLON_EI1CON_IRQ7EN             15            /*  External Interrupt 7 Enable Bit */
+#define BITP_ALLON_EI1CON_IRQ7MDE            12            /*  External Interrupt 7 Mode Registers */
+#define BITP_ALLON_EI1CON_IRQ6EN             11            /*  External Interrupt 6 Enable Bit */
+#define BITP_ALLON_EI1CON_IRQ6MDE             8            /*  External Interrupt 6 Mode Registers */
+#define BITP_ALLON_EI1CON_IRQ5EN              7            /*  External Interrupt 5 Enable Bit */
+#define BITP_ALLON_EI1CON_IRQ5MDE             4            /*  External Interrupt 5 Mode Registers */
+#define BITP_ALLON_EI1CON_IRQ4EN              3            /*  External Interrupt 4 Enable Bit */
+#define BITP_ALLON_EI1CON_IRQ4MDE             0            /*  External Interrupt 4 Mode Registers */
+#define BITM_ALLON_EI1CON_IRQ7EN             0x00008000    /*  External Interrupt 7 Enable Bit */
+#define BITM_ALLON_EI1CON_IRQ7MDE            0x00007000    /*  External Interrupt 7 Mode Registers */
+#define BITM_ALLON_EI1CON_IRQ6EN             0x00000800    /*  External Interrupt 6 Enable Bit */
+#define BITM_ALLON_EI1CON_IRQ6MDE            0x00000700    /*  External Interrupt 6 Mode Registers */
+#define BITM_ALLON_EI1CON_IRQ5EN             0x00000080    /*  External Interrupt 5 Enable Bit */
+#define BITM_ALLON_EI1CON_IRQ5MDE            0x00000070    /*  External Interrupt 5 Mode Registers */
+#define BITM_ALLON_EI1CON_IRQ4EN             0x00000008    /*  External Interrupt 4 Enable Bit */
+#define BITM_ALLON_EI1CON_IRQ4MDE            0x00000007    /*  External Interrupt 4 Mode Registers */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          ALLON_EI2CON                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_ALLON_EI2CON_BUSINTEN            3            /*  BUS Interrupt Detection Enable Bit */
+#define BITP_ALLON_EI2CON_BUSINTMDE           0            /*  BUS Interrupt Detection Mode Registers */
+#define BITM_ALLON_EI2CON_BUSINTEN           0x00000008    /*  BUS Interrupt Detection Enable Bit */
+#define BITM_ALLON_EI2CON_BUSINTMDE          0x00000007    /*  BUS Interrupt Detection Mode Registers */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          ALLON_EICLR                          Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_ALLON_EICLR_AUTCLRBUSEN         15            /*  Enable Auto Clear of Bus Interrupt */
+#define BITP_ALLON_EICLR_BUSINT               8            /*  BUS Interrupt */
+#define BITM_ALLON_EICLR_AUTCLRBUSEN         0x00008000    /*  Enable Auto Clear of Bus Interrupt */
+#define BITM_ALLON_EICLR_BUSINT              0x00000100    /*  BUS Interrupt */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          ALLON_RSTSTA                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_ALLON_RSTSTA_PINSWRST            4            /*  Software Reset Pin */
+#define BITP_ALLON_RSTSTA_MMRSWRST            3            /*  MMR Software Reset */
+#define BITP_ALLON_RSTSTA_WDRST               2            /*  Watchdog Timeout */
+#define BITP_ALLON_RSTSTA_EXTRST              1            /*  External Reset */
+#define BITP_ALLON_RSTSTA_POR                 0            /*  Power-on Reset */
+#define BITM_ALLON_RSTSTA_PINSWRST           0x00000010    /*  Software Reset Pin */
+#define BITM_ALLON_RSTSTA_MMRSWRST           0x00000008    /*  MMR Software Reset */
+#define BITM_ALLON_RSTSTA_WDRST              0x00000004    /*  Watchdog Timeout */
+#define BITM_ALLON_RSTSTA_EXTRST             0x00000002    /*  External Reset */
+#define BITM_ALLON_RSTSTA_POR                0x00000001    /*  Power-on Reset */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          ALLON_RSTCONKEY                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_ALLON_RSTCONKEY_KEY              0            /*  Reset Control Key Register */
+#define BITM_ALLON_RSTCONKEY_KEY             0x0000FFFF    /*  Reset Control Key Register */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          ALLON_LOSCTST                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_ALLON_LOSCTST_TRIM               0            /*  Trim Caps to Adjust Frequency. */
+#define BITM_ALLON_LOSCTST_TRIM              0x0000000F    /*  Trim Caps to Adjust Frequency. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          ALLON_CLKEN0                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_ALLON_CLKEN0_TIACHPDIS           2            /*  TIA Chop Clock Disable */
+#define BITP_ALLON_CLKEN0_SLPWUTDIS           1            /*  Sleep/Wakeup Timer Clock Disable */
+#define BITP_ALLON_CLKEN0_WDTDIS              0            /*  Watch Dog Timer Clock Disable */
+#define BITM_ALLON_CLKEN0_TIACHPDIS          0x00000004    /*  TIA Chop Clock Disable */
+#define BITM_ALLON_CLKEN0_SLPWUTDIS          0x00000002    /*  Sleep/Wakeup Timer Clock Disable */
+#define BITM_ALLON_CLKEN0_WDTDIS             0x00000001    /*  Watch Dog Timer Clock Disable */
+
+/* ============================================================================================================================
+        General Purpose Timer
+   ============================================================================================================================ */
+
+/* ============================================================================================================================
+        AGPT0
+   ============================================================================================================================ */
+#define REG_AGPT0_LD0                        0x00000D00            /*  AGPT0 16-bit Load Value Register. */
+#define REG_AGPT0_VAL0                       0x00000D04            /*  AGPT0 16-Bit Timer Value Register. */
+#define REG_AGPT0_CON0                       0x00000D08            /*  AGPT0 Control Register. */
+#define REG_AGPT0_CLRI0                      0x00000D0C            /*  AGPT0 Clear Interrupt Register. */
+#define REG_AGPT0_CAP0                       0x00000D10            /*  AGPT0 Capture Register. */
+#define REG_AGPT0_ALD0                       0x00000D14            /*  AGPT0 16-Bit Load Value, Asynchronous. */
+#define REG_AGPT0_AVAL0                      0x00000D18            /*  AGPT0 16-Bit Timer Value, Asynchronous Register. */
+#define REG_AGPT0_STA0                       0x00000D1C            /*  AGPT0 Status Register. */
+#define REG_AGPT0_PWMCON0                    0x00000D20            /*  AGPT0 PWM Control Register. */
+#define REG_AGPT0_PWMMAT0                    0x00000D24            /*  AGPT0 PWM Match Value Register. */
+#define REG_AGPT0_INTEN                      0x00000D28            /*  AGPT0 Interrupt Enable */
+
+/* ============================================================================================================================
+        AGPT0 Register BitMasks, Positions & Enumerations 
+   ============================================================================================================================ */
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT0_LD0                            Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT0_LD0_LOAD                   0            /*  Load Value */
+#define BITM_AGPT0_LD0_LOAD                  (_ADI_MSK_3(0x0000FFFF,0x0000FFFF, int16_t   ))    /*  Load Value */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT0_VAL0                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT0_VAL0_VAL                   0            /*  Current Count */
+#define BITM_AGPT0_VAL0_VAL                  (_ADI_MSK_3(0x0000FFFF,0x0000FFFF, int16_t   ))    /*  Current Count */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT0_CON0                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT0_CON0_SYNCBYP              15            /*  Synchronization Bypass */
+#define BITP_AGPT0_CON0_RSTEN                14            /*  Counter and Prescale Reset Enable */
+#define BITP_AGPT0_CON0_EVTEN                13            /*  Event Select */
+#define BITP_AGPT0_CON0_EVENT                 8            /*  Event Select Range */
+#define BITP_AGPT0_CON0_RLD                   7            /*  Reload Control */
+#define BITP_AGPT0_CON0_CLK                   5            /*  Clock Select */
+#define BITP_AGPT0_CON0_ENABLE                4            /*  Timer Enable */
+#define BITP_AGPT0_CON0_MOD                   3            /*  Timer Mode */
+#define BITP_AGPT0_CON0_UP                    2            /*  Count up */
+#define BITP_AGPT0_CON0_PRE                   0            /*  Prescaler */
+#define BITM_AGPT0_CON0_SYNCBYP              (_ADI_MSK_3(0x00008000,0x00008000U, uint16_t  ))    /*  Synchronization Bypass */
+#define BITM_AGPT0_CON0_RSTEN                (_ADI_MSK_3(0x00004000,0x00004000U, uint16_t  ))    /*  Counter and Prescale Reset Enable */
+#define BITM_AGPT0_CON0_EVTEN                (_ADI_MSK_3(0x00002000,0x00002000U, uint16_t  ))    /*  Event Select */
+#define BITM_AGPT0_CON0_EVENT                (_ADI_MSK_3(0x00001F00,0x00001F00U, uint16_t  ))    /*  Event Select Range */
+#define BITM_AGPT0_CON0_RLD                  (_ADI_MSK_3(0x00000080,0x00000080U, uint16_t  ))    /*  Reload Control */
+#define BITM_AGPT0_CON0_CLK                  (_ADI_MSK_3(0x00000060,0x00000060U, uint16_t  ))    /*  Clock Select */
+#define BITM_AGPT0_CON0_ENABLE               (_ADI_MSK_3(0x00000010,0x00000010U, uint16_t  ))    /*  Timer Enable */
+#define BITM_AGPT0_CON0_MOD                  (_ADI_MSK_3(0x00000008,0x00000008U, uint16_t  ))    /*  Timer Mode */
+#define BITM_AGPT0_CON0_UP                   (_ADI_MSK_3(0x00000004,0x00000004U, uint16_t  ))    /*  Count up */
+#define BITM_AGPT0_CON0_PRE                  (_ADI_MSK_3(0x00000003,0x00000003U, uint16_t  ))    /*  Prescaler */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT0_CLRI0                          Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT0_CLRI0_CAP                  1            /*  Clear Captured Event Interrupt */
+#define BITP_AGPT0_CLRI0_TMOUT                0            /*  Clear Timeout Interrupt */
+#define BITM_AGPT0_CLRI0_CAP                 (_ADI_MSK_3(0x00000002,0x00000002U, uint16_t  ))    /*  Clear Captured Event Interrupt */
+#define BITM_AGPT0_CLRI0_TMOUT               (_ADI_MSK_3(0x00000001,0x00000001U, uint16_t  ))    /*  Clear Timeout Interrupt */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT0_CAP0                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT0_CAP0_CAP                   0            /*  16-bit Captured Value */
+#define BITM_AGPT0_CAP0_CAP                  (_ADI_MSK_3(0x0000FFFF,0x0000FFFF, int16_t   ))    /*  16-bit Captured Value */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT0_ALD0                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT0_ALD0_ALOAD                 0            /*  Load Value, Asynchronous */
+#define BITM_AGPT0_ALD0_ALOAD                (_ADI_MSK_3(0x0000FFFF,0x0000FFFF, int16_t   ))    /*  Load Value, Asynchronous */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT0_AVAL0                          Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT0_AVAL0_AVAL                 0            /*  Counter Value */
+#define BITM_AGPT0_AVAL0_AVAL                (_ADI_MSK_3(0x0000FFFF,0x0000FFFF, int16_t   ))    /*  Counter Value */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT0_STA0                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT0_STA0_RSTCNT                8            /*  Counter Reset Occurring */
+#define BITP_AGPT0_STA0_PDOK                  7            /*  Clear Interrupt Register Synchronization */
+#define BITP_AGPT0_STA0_BUSY                  6            /*  Timer Busy */
+#define BITP_AGPT0_STA0_CAP                   1            /*  Capture Event Pending */
+#define BITP_AGPT0_STA0_TMOUT                 0            /*  Timeout Event Occurred */
+#define BITM_AGPT0_STA0_RSTCNT               (_ADI_MSK_3(0x00000100,0x00000100U, uint16_t  ))    /*  Counter Reset Occurring */
+#define BITM_AGPT0_STA0_PDOK                 (_ADI_MSK_3(0x00000080,0x00000080U, uint16_t  ))    /*  Clear Interrupt Register Synchronization */
+#define BITM_AGPT0_STA0_BUSY                 (_ADI_MSK_3(0x00000040,0x00000040U, uint16_t  ))    /*  Timer Busy */
+#define BITM_AGPT0_STA0_CAP                  (_ADI_MSK_3(0x00000002,0x00000002U, uint16_t  ))    /*  Capture Event Pending */
+#define BITM_AGPT0_STA0_TMOUT                (_ADI_MSK_3(0x00000001,0x00000001U, uint16_t  ))    /*  Timeout Event Occurred */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT0_PWMCON0                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT0_PWMCON0_IDLE               1            /*  PWM Idle State */
+#define BITP_AGPT0_PWMCON0_MATCHEN            0            /*  PWM Match Enabled */
+#define BITM_AGPT0_PWMCON0_IDLE              (_ADI_MSK_3(0x00000002,0x00000002U, uint16_t  ))    /*  PWM Idle State */
+#define BITM_AGPT0_PWMCON0_MATCHEN           (_ADI_MSK_3(0x00000001,0x00000001U, uint16_t  ))    /*  PWM Match Enabled */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT0_PWMMAT0                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT0_PWMMAT0_MATCHVAL           0            /*  PWM Match Value */
+#define BITM_AGPT0_PWMMAT0_MATCHVAL          (_ADI_MSK_3(0x0000FFFF,0x0000FFFF, int16_t   ))    /*  PWM Match Value */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT0_INTEN                          Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT0_INTEN_INTEN                0            /*  Interrupt Enable */
+#define BITM_AGPT0_INTEN_INTEN               (_ADI_MSK_3(0x00000001,0x00000001U, uint16_t  ))    /*  Interrupt Enable */
+
+
+/* ============================================================================================================================
+        General Purpose Timer
+   ============================================================================================================================ */
+
+/* ============================================================================================================================
+        AGPT1
+   ============================================================================================================================ */
+#define REG_AGPT1_LD1                        0x00000E00            /*  AGPT1 16-bit Load Value Register */
+#define REG_AGPT1_VAL1                       0x00000E04            /*  AGPT1 16-bit Timer Value Register */
+#define REG_AGPT1_CON1                       0x00000E08            /*  AGPT1 Control Register */
+#define REG_AGPT1_CLRI1                      0x00000E0C            /*  AGPT1 Clear Interrupt Register */
+#define REG_AGPT1_CAP1                       0x00000E10            /*  AGPT1 Capture Register */
+#define REG_AGPT1_ALD1                       0x00000E14            /*  AGPT1 16-bit Load Value, Asynchronous Register */
+#define REG_AGPT1_AVAL1                      0x00000E18            /*  AGPT1 16-bit Timer Value, Asynchronous Register */
+#define REG_AGPT1_STA1                       0x00000E1C            /*  AGPT1 Status Register */
+#define REG_AGPT1_PWMCON1                    0x00000E20            /*  AGPT1 PWM Control Register */
+#define REG_AGPT1_PWMMAT1                    0x00000E24            /*  AGPT1 PWM Match Value Register */
+#define REG_AGPT1_INTEN1                     0x00000E28            /*  AGPT1 Interrupt Enable */
+
+/* ============================================================================================================================
+        AGPT1 Register BitMasks, Positions & Enumerations 
+   ============================================================================================================================ */
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT1_LD1                            Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT1_LD1_LOAD                   0            /*  Load Value */
+#define BITM_AGPT1_LD1_LOAD                  (_ADI_MSK_3(0x0000FFFF,0x0000FFFF, int16_t   ))    /*  Load Value */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT1_VAL1                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT1_VAL1_VAL                   0            /*  Current Count */
+#define BITM_AGPT1_VAL1_VAL                  (_ADI_MSK_3(0x0000FFFF,0x0000FFFF, int16_t   ))    /*  Current Count */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT1_CON1                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT1_CON1_SYNCBYP              15            /*  Synchronization Bypass */
+#define BITP_AGPT1_CON1_RSTEN                14            /*  Counter and Prescale Reset Enable */
+#define BITP_AGPT1_CON1_EVENTEN              13            /*  Event Select */
+#define BITP_AGPT1_CON1_EVENT                 8            /*  Event Select Range */
+#define BITP_AGPT1_CON1_RLD                   7            /*  Reload Control */
+#define BITP_AGPT1_CON1_CLK                   5            /*  Clock Select */
+#define BITP_AGPT1_CON1_ENABLE                4            /*  Timer Enable */
+#define BITP_AGPT1_CON1_MOD                   3            /*  Timer Mode */
+#define BITP_AGPT1_CON1_UP                    2            /*  Count up */
+#define BITP_AGPT1_CON1_PRE                   0            /*  Prescaler */
+#define BITM_AGPT1_CON1_SYNCBYP              (_ADI_MSK_3(0x00008000,0x00008000U, uint16_t  ))    /*  Synchronization Bypass */
+#define BITM_AGPT1_CON1_RSTEN                (_ADI_MSK_3(0x00004000,0x00004000U, uint16_t  ))    /*  Counter and Prescale Reset Enable */
+#define BITM_AGPT1_CON1_EVENTEN              (_ADI_MSK_3(0x00002000,0x00002000U, uint16_t  ))    /*  Event Select */
+#define BITM_AGPT1_CON1_EVENT                (_ADI_MSK_3(0x00001F00,0x00001F00U, uint16_t  ))    /*  Event Select Range */
+#define BITM_AGPT1_CON1_RLD                  (_ADI_MSK_3(0x00000080,0x00000080U, uint16_t  ))    /*  Reload Control */
+#define BITM_AGPT1_CON1_CLK                  (_ADI_MSK_3(0x00000060,0x00000060U, uint16_t  ))    /*  Clock Select */
+#define BITM_AGPT1_CON1_ENABLE               (_ADI_MSK_3(0x00000010,0x00000010U, uint16_t  ))    /*  Timer Enable */
+#define BITM_AGPT1_CON1_MOD                  (_ADI_MSK_3(0x00000008,0x00000008U, uint16_t  ))    /*  Timer Mode */
+#define BITM_AGPT1_CON1_UP                   (_ADI_MSK_3(0x00000004,0x00000004U, uint16_t  ))    /*  Count up */
+#define BITM_AGPT1_CON1_PRE                  (_ADI_MSK_3(0x00000003,0x00000003U, uint16_t  ))    /*  Prescaler */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT1_CLRI1                          Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT1_CLRI1_CAP                  1            /*  Clear Captured Event Interrupt */
+#define BITP_AGPT1_CLRI1_TMOUT                0            /*  Clear Timeout Interrupt */
+#define BITM_AGPT1_CLRI1_CAP                 (_ADI_MSK_3(0x00000002,0x00000002U, uint16_t  ))    /*  Clear Captured Event Interrupt */
+#define BITM_AGPT1_CLRI1_TMOUT               (_ADI_MSK_3(0x00000001,0x00000001U, uint16_t  ))    /*  Clear Timeout Interrupt */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT1_CAP1                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT1_CAP1_CAP                   0            /*  16-bit Captured Value. */
+#define BITM_AGPT1_CAP1_CAP                  (_ADI_MSK_3(0x0000FFFF,0x0000FFFF, int16_t   ))    /*  16-bit Captured Value. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT1_ALD1                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT1_ALD1_ALOAD                 0            /*  Load Value, Asynchronous */
+#define BITM_AGPT1_ALD1_ALOAD                (_ADI_MSK_3(0x0000FFFF,0x0000FFFF, int16_t   ))    /*  Load Value, Asynchronous */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT1_AVAL1                          Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT1_AVAL1_AVAL                 0            /*  Counter Value */
+#define BITM_AGPT1_AVAL1_AVAL                (_ADI_MSK_3(0x0000FFFF,0x0000FFFF, int16_t   ))    /*  Counter Value */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT1_STA1                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT1_STA1_RSTCNT                8            /*  Counter Reset Occurring */
+#define BITP_AGPT1_STA1_PDOK                  7            /*  Clear Interrupt Register Synchronization */
+#define BITP_AGPT1_STA1_BUSY                  6            /*  Timer Busy */
+#define BITP_AGPT1_STA1_CAP                   1            /*  Capture Event Pending */
+#define BITP_AGPT1_STA1_TMOUT                 0            /*  Timeout Event Occurred */
+#define BITM_AGPT1_STA1_RSTCNT               (_ADI_MSK_3(0x00000100,0x00000100U, uint16_t  ))    /*  Counter Reset Occurring */
+#define BITM_AGPT1_STA1_PDOK                 (_ADI_MSK_3(0x00000080,0x00000080U, uint16_t  ))    /*  Clear Interrupt Register Synchronization */
+#define BITM_AGPT1_STA1_BUSY                 (_ADI_MSK_3(0x00000040,0x00000040U, uint16_t  ))    /*  Timer Busy */
+#define BITM_AGPT1_STA1_CAP                  (_ADI_MSK_3(0x00000002,0x00000002U, uint16_t  ))    /*  Capture Event Pending */
+#define BITM_AGPT1_STA1_TMOUT                (_ADI_MSK_3(0x00000001,0x00000001U, uint16_t  ))    /*  Timeout Event Occurred */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT1_PWMCON1                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT1_PWMCON1_IDLE               1            /*  PWM Idle State. */
+#define BITP_AGPT1_PWMCON1_MATCHEN            0            /*  PWM Match Enabled. */
+#define BITM_AGPT1_PWMCON1_IDLE              (_ADI_MSK_3(0x00000002,0x00000002U, uint16_t  ))    /*  PWM Idle State. */
+#define BITM_AGPT1_PWMCON1_MATCHEN           (_ADI_MSK_3(0x00000001,0x00000001U, uint16_t  ))    /*  PWM Match Enabled. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT1_PWMMAT1                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT1_PWMMAT1_MATCHVAL           0            /*  PWM Match Value */
+#define BITM_AGPT1_PWMMAT1_MATCHVAL          (_ADI_MSK_3(0x0000FFFF,0x0000FFFF, int16_t   ))    /*  PWM Match Value */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AGPT1_INTEN1                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AGPT1_INTEN1_INTEN               0            /*  Interrupt Enable */
+#define BITM_AGPT1_INTEN1_INTEN              (_ADI_MSK_3(0x00000001,0x00000001U, uint16_t  ))    /*  Interrupt Enable */
+
+
+/* ============================================================================================================================
+        CRC Accelerator
+   ============================================================================================================================ */
+
+/* ============================================================================================================================
+        AFECRC
+   ============================================================================================================================ */
+#define REG_AFECRC_CTL                       0x00001000            /*  AFECRC CRC Control Register */
+#define REG_AFECRC_IPDATA                    0x00001004            /*  AFECRC Data Input. */
+#define REG_AFECRC_RESULT                    0x00001008            /*  AFECRC CRC Residue */
+#define REG_AFECRC_POLY                      0x0000100C            /*  AFECRC CRC Reduction Polynomial */
+#define REG_AFECRC_IPBITS                    0x00001010            /*  AFECRC Input Data Bits */
+#define REG_AFECRC_IPBYTE                    0x00001014            /*  AFECRC Input Data Byte */
+#define REG_AFECRC_CRC_SIG_COMP              0x00001020            /*  AFECRC CRC Signature Compare Data Input. */
+#define REG_AFECRC_CRCINTEN                  0x00001024            /*  AFECRC CRC Error Interrupt Enable Bit */
+#define REG_AFECRC_INTSTA                    0x00001028            /*  AFECRC CRC Error Interrupt Status Bit */
+
+/* ============================================================================================================================
+        AFECRC Register BitMasks, Positions & Enumerations 
+   ============================================================================================================================ */
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFECRC_CTL                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFECRC_CTL_REVID                28            /*  Revision ID */
+#define BITP_AFECRC_CTL_MON_EN                9            /*  Enable Apb32/Apb16 to Get Address/Data for CRC Calculation */
+#define BITP_AFECRC_CTL_W16SWP                4            /*  Word16 Swap Enabled. */
+#define BITP_AFECRC_CTL_BYTMIRR               3            /*  Byte Mirroring. */
+#define BITP_AFECRC_CTL_BITMIRR               2            /*  Bit Mirroring. */
+#define BITP_AFECRC_CTL_LSBFIRST              1            /*  LSB First Calculation Order */
+#define BITP_AFECRC_CTL_EN                    0            /*  CRC Peripheral Enable */
+#define BITM_AFECRC_CTL_REVID                (_ADI_MSK_3(0xF0000000,0xF0000000UL, uint32_t  ))    /*  Revision ID */
+#define BITM_AFECRC_CTL_MON_EN               (_ADI_MSK_3(0x00000200,0x00000200UL, uint32_t  ))    /*  Enable Apb32/Apb16 to Get Address/Data for CRC Calculation */
+#define BITM_AFECRC_CTL_W16SWP               (_ADI_MSK_3(0x00000010,0x00000010UL, uint32_t  ))    /*  Word16 Swap Enabled. */
+#define BITM_AFECRC_CTL_BYTMIRR              (_ADI_MSK_3(0x00000008,0x00000008UL, uint32_t  ))    /*  Byte Mirroring. */
+#define BITM_AFECRC_CTL_BITMIRR              (_ADI_MSK_3(0x00000004,0x00000004UL, uint32_t  ))    /*  Bit Mirroring. */
+#define BITM_AFECRC_CTL_LSBFIRST             (_ADI_MSK_3(0x00000002,0x00000002UL, uint32_t  ))    /*  LSB First Calculation Order */
+#define BITM_AFECRC_CTL_EN                   (_ADI_MSK_3(0x00000001,0x00000001UL, uint32_t  ))    /*  CRC Peripheral Enable */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFECRC_IPDATA                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFECRC_IPDATA_VALUE              0            /*  Data Input. */
+#define BITM_AFECRC_IPDATA_VALUE             (_ADI_MSK_3(0xFFFFFFFF,0xFFFFFFFF, int32_t   ))    /*  Data Input. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFECRC_RESULT                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFECRC_RESULT_VALUE              0            /*  CRC Residue */
+#define BITM_AFECRC_RESULT_VALUE             (_ADI_MSK_3(0xFFFFFFFF,0xFFFFFFFF, int32_t   ))    /*  CRC Residue */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFECRC_POLY                          Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFECRC_POLY_VALUE                0            /*  CRC Reduction Polynomial */
+#define BITM_AFECRC_POLY_VALUE               (_ADI_MSK_3(0xFFFFFFFF,0xFFFFFFFFUL, uint32_t  ))    /*  CRC Reduction Polynomial */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFECRC_IPBITS                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFECRC_IPBITS_DATA_BITS          0            /*  Input Data Bits. */
+#define BITM_AFECRC_IPBITS_DATA_BITS         (_ADI_MSK_3(0x000000FF,0x000000FFU, uint8_t   ))    /*  Input Data Bits. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFECRC_IPBYTE                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFECRC_IPBYTE_DATA_BYTE          0            /*  Input Data Byte. */
+#define BITM_AFECRC_IPBYTE_DATA_BYTE         (_ADI_MSK_3(0x000000FF,0x000000FFU, uint8_t   ))    /*  Input Data Byte. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFECRC_CRC_SIG_COMP                  Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFECRC_CRC_SIG_COMP_CRC_SIG      0            /*  CRC Signature Compare Data Input. */
+#define BITM_AFECRC_CRC_SIG_COMP_CRC_SIG     (_ADI_MSK_3(0xFFFFFFFF,0xFFFFFFFFUL, uint32_t  ))    /*  CRC Signature Compare Data Input. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFECRC_CRCINTEN                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFECRC_CRCINTEN_RESERVED_31_1    1            /*  Reserved */
+#define BITP_AFECRC_CRCINTEN_CRC_ERR_EN       0            /*  CRC Error Interrupt Enable Bit */
+#define BITM_AFECRC_CRCINTEN_RESERVED_31_1   (_ADI_MSK_3(0xFFFFFFFE,0xFFFFFFFEUL, uint32_t  ))    /*  Reserved */
+#define BITM_AFECRC_CRCINTEN_CRC_ERR_EN      (_ADI_MSK_3(0x00000001,0x00000001UL, uint32_t  ))    /*  CRC Error Interrupt Enable Bit */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFECRC_INTSTA                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFECRC_INTSTA_CRC_ERR_ST         0            /*  CRC Error Interrupt Status Bit */
+#define BITM_AFECRC_INTSTA_CRC_ERR_ST        (_ADI_MSK_3(0x00000001,0x00000001UL, uint32_t  ))    /*  CRC Error Interrupt Status Bit */
+
+
+/* ============================================================================================================================
+        
+   ============================================================================================================================ */
+
+/* ============================================================================================================================
+        AFE
+   ============================================================================================================================ */
+#define REG_AFE_AFECON_RESET                 0x00080000            /*      Reset Value for AFECON  */
+#define REG_AFE_AFECON                       0x00002000            /*  AFE AFE Configuration */
+#define REG_AFE_SEQCON_RESET                 0x00000002            /*      Reset Value for SEQCON  */
+#define REG_AFE_SEQCON                       0x00002004            /*  AFE Sequencer Configuration */
+#define REG_AFE_FIFOCON_RESET                0x00001010            /*      Reset Value for FIFOCON  */
+#define REG_AFE_FIFOCON                      0x00002008            /*  AFE FIFOs Configuration */
+#define REG_AFE_SWCON_RESET                  0x0000FFFF            /*      Reset Value for SWCON  */
+#define REG_AFE_SWCON                        0x0000200C            /*  AFE Switch Matrix Configuration */
+#define REG_AFE_HSDACCON_RESET               0x0000001E            /*      Reset Value for HSDACCON  */
+#define REG_AFE_HSDACCON                     0x00002010            /*  AFE High Speed DAC Configuration */
+#define REG_AFE_WGCON_RESET                  0x00000030            /*      Reset Value for WGCON  */
+#define REG_AFE_WGCON                        0x00002014            /*  AFE Waveform Generator Configuration */
+#define REG_AFE_WGDCLEVEL1_RESET             0x00000000            /*      Reset Value for WGDCLEVEL1  */
+#define REG_AFE_WGDCLEVEL1                   0x00002018            /*  AFE Waveform Generator - Trapezoid DC Level 1 */
+#define REG_AFE_WGDCLEVEL2_RESET             0x00000000            /*      Reset Value for WGDCLEVEL2  */
+#define REG_AFE_WGDCLEVEL2                   0x0000201C            /*  AFE Waveform Generator - Trapezoid DC Level 2 */
+#define REG_AFE_WGDELAY1_RESET               0x00000000            /*      Reset Value for WGDELAY1  */
+#define REG_AFE_WGDELAY1                     0x00002020            /*  AFE Waveform Generator - Trapezoid Delay 1 Time */
+#define REG_AFE_WGSLOPE1_RESET               0x00000000            /*      Reset Value for WGSLOPE1  */
+#define REG_AFE_WGSLOPE1                     0x00002024            /*  AFE Waveform Generator - Trapezoid Slope 1 Time */
+#define REG_AFE_WGDELAY2_RESET               0x00000000            /*      Reset Value for WGDELAY2  */
+#define REG_AFE_WGDELAY2                     0x00002028            /*  AFE Waveform Generator - Trapezoid Delay 2 Time */
+#define REG_AFE_WGSLOPE2_RESET               0x00000000            /*      Reset Value for WGSLOPE2  */
+#define REG_AFE_WGSLOPE2                     0x0000202C            /*  AFE Waveform Generator - Trapezoid Slope 2 Time */
+#define REG_AFE_WGFCW_RESET                  0x00000000            /*      Reset Value for WGFCW  */
+#define REG_AFE_WGFCW                        0x00002030            /*  AFE Waveform Generator - Sinusoid Frequency Control Word */
+#define REG_AFE_WGPHASE_RESET                0x00000000            /*      Reset Value for WGPHASE  */
+#define REG_AFE_WGPHASE                      0x00002034            /*  AFE Waveform Generator - Sinusoid Phase Offset */
+#define REG_AFE_WGOFFSET_RESET               0x00000000            /*      Reset Value for WGOFFSET  */
+#define REG_AFE_WGOFFSET                     0x00002038            /*  AFE Waveform Generator - Sinusoid Offset */
+#define REG_AFE_WGAMPLITUDE_RESET            0x00000000            /*      Reset Value for WGAMPLITUDE  */
+#define REG_AFE_WGAMPLITUDE                  0x0000203C            /*  AFE Waveform Generator - Sinusoid Amplitude */
+#define REG_AFE_ADCFILTERCON_RESET           0x00000301            /*      Reset Value for ADCFILTERCON  */
+#define REG_AFE_ADCFILTERCON                 0x00002044            /*  AFE ADC Output Filters Configuration */
+#define REG_AFE_HSDACDAT_RESET               0x00000800            /*      Reset Value for HSDACDAT  */
+#define REG_AFE_HSDACDAT                     0x00002048            /*  AFE HS DAC Code */
+#define REG_AFE_LPREFBUFCON_RESET            0x00000000            /*      Reset Value for LPREFBUFCON  */
+#define REG_AFE_LPREFBUFCON                  0x00002050            /*  AFE LPREF_BUF_CON */
+#define REG_AFE_SYNCEXTDEVICE_RESET          0x00000000            /*      Reset Value for SYNCEXTDEVICE  */
+#define REG_AFE_SYNCEXTDEVICE                0x00002054            /*  AFE SYNC External Devices */
+#define REG_AFE_SEQCRC_RESET                 0x00000001            /*      Reset Value for SEQCRC  */
+#define REG_AFE_SEQCRC                       0x00002060            /*  AFE Sequencer CRC Value */
+#define REG_AFE_SEQCNT_RESET                 0x00000000            /*      Reset Value for SEQCNT  */
+#define REG_AFE_SEQCNT                       0x00002064            /*  AFE Sequencer Command Count */
+#define REG_AFE_SEQTIMEOUT_RESET             0x00000000            /*      Reset Value for SEQTIMEOUT  */
+#define REG_AFE_SEQTIMEOUT                   0x00002068            /*  AFE Sequencer Timeout Counter */
+#define REG_AFE_DATAFIFORD_RESET             0x00000000            /*      Reset Value for DATAFIFORD  */
+#define REG_AFE_DATAFIFORD                   0x0000206C            /*  AFE Data FIFO Read */
+#define REG_AFE_CMDFIFOWRITE_RESET           0x00000000            /*      Reset Value for CMDFIFOWRITE  */
+#define REG_AFE_CMDFIFOWRITE                 0x00002070            /*  AFE Command FIFO Write */
+#define REG_AFE_ADCDAT_RESET                 0x00000000            /*      Reset Value for ADCDAT  */
+#define REG_AFE_ADCDAT                       0x00002074            /*  AFE ADC Raw Result */
+#define REG_AFE_DFTREAL_RESET                0x00000000            /*      Reset Value for DFTREAL  */
+#define REG_AFE_DFTREAL                      0x00002078            /*  AFE DFT Result, Real Part */
+#define REG_AFE_DFTIMAG_RESET                0x00000000            /*      Reset Value for DFTIMAG  */
+#define REG_AFE_DFTIMAG                      0x0000207C            /*  AFE DFT Result, Imaginary Part */
+#define REG_AFE_SINC2DAT_RESET               0x00000000            /*      Reset Value for SINC2DAT  */
+#define REG_AFE_SINC2DAT                     0x00002080            /*  AFE Supply Rejection Filter Result */
+#define REG_AFE_TEMPSENSDAT_RESET            0x00000000            /*      Reset Value for TEMPSENSDAT  */
+#define REG_AFE_TEMPSENSDAT                  0x00002084            /*  AFE Temperature Sensor Result */
+#define REG_AFE_AFEGENINTSTA_RESET           0x00000000            /*      Reset Value for AFEGENINTSTA  */
+#define REG_AFE_AFEGENINTSTA                 0x0000209C            /*  AFE Analog Generation Interrupt */
+#define REG_AFE_ADCMIN_RESET                 0x00000000            /*      Reset Value for ADCMIN  */
+#define REG_AFE_ADCMIN                       0x000020A8            /*  AFE ADC Minimum Value Check */
+#define REG_AFE_ADCMINSM_RESET               0x00000000            /*      Reset Value for ADCMINSM  */
+#define REG_AFE_ADCMINSM                     0x000020AC            /*  AFE ADCMIN Hysteresis Value */
+#define REG_AFE_ADCMAX_RESET                 0x00000000            /*      Reset Value for ADCMAX  */
+#define REG_AFE_ADCMAX                       0x000020B0            /*  AFE ADC Maximum Value Check */
+#define REG_AFE_ADCMAXSMEN_RESET             0x00000000            /*      Reset Value for ADCMAXSMEN  */
+#define REG_AFE_ADCMAXSMEN                   0x000020B4            /*  AFE ADCMAX Hysteresis Value */
+#define REG_AFE_ADCDELTA_RESET               0x00000000            /*      Reset Value for ADCDELTA  */
+#define REG_AFE_ADCDELTA                     0x000020B8            /*  AFE ADC Delta Value */
+#define REG_AFE_HPOSCCON_RESET               0x00000024            /*      Reset Value for HPOSCCON  */
+#define REG_AFE_HPOSCCON                     0x000020BC            /*  AFE HPOSC Configuration */
+#define REG_AFE_DFTCON_RESET                 0x00000090            /*      Reset Value for DFTCON  */
+#define REG_AFE_DFTCON                       0x000020D0            /*  AFE AFE DSP Configuration */
+#define REG_AFE_LPTIASW1                     0x000020E0            /*  AFE ULPTIA Switch Configuration for Channel 1 */
+#define REG_AFE_LPTIASW0_RESET               0x00000000            /*      Reset Value for LPTIASW0  */
+#define REG_AFE_LPTIACON1                    0x000020E8            /*  AFE ULPTIA Control Bits Channel 1 */
+#define REG_AFE_LPTIASW0                     0x000020E4            /*  AFE ULPTIA Switch Configuration for Channel 0 */
+#define REG_AFE_LPTIACON0_RESET              0x00000003            /*      Reset Value for LPTIACON0  */
+#define REG_AFE_LPTIACON0                    0x000020EC            /*  AFE ULPTIA Control Bits Channel 0 */
+#define REG_AFE_HSRTIACON_RESET              0x0000000F            /*      Reset Value for HSRTIACON  */
+#define REG_AFE_HSRTIACON                    0x000020F0            /*  AFE High Power RTIA Configuration */
+#define REG_AFE_DE1RESCON                    0x000020F4            /*  AFE DE1 HSTIA Resistors Configuration */
+#define REG_AFE_DE0RESCON_RESET              0x000000FF            /*      Reset Value for DE0RESCON  */
+#define REG_AFE_DE0RESCON                    0x000020F8            /*  AFE DE0 HSTIA Resistors Configuration */
+#define REG_AFE_HSTIACON_RESET               0x00000000            /*      Reset Value for HSTIACON  */
+#define REG_AFE_HSTIACON                     0x000020FC            /*  AFE HSTIA Amplifier Configuration */
+#define REG_AFE_LPMODEKEY_RESET             0x00000000            /*      Reset Value for LPMODEKEY  */
+#define REG_AFE_LPMODEKEY                   0x0000210C            /*  AFE LP Mode AFE Control Lock */
+#define REG_AFE_LPMODECLKSEL_RESET          0x00000000            /*      Reset Value for LPMODECLKSEL  */
+#define REG_AFE_LPMODECLKSEL                0x00002110            /*  AFE LFSYSCLKEN */
+#define REG_AFE_LPMODECON_RESET             0x00000102            /*      Reset Value for LPMODECON  */
+#define REG_AFE_LPMODECON                   0x00002114            /*  AFE LPMODECON */
+#define REG_AFE_SEQSLPLOCK_RESET             0x00000000            /*      Reset Value for SEQSLPLOCK  */
+#define REG_AFE_SEQSLPLOCK                   0x00002118            /*  AFE Sequencer Sleep Control Lock */
+#define REG_AFE_SEQTRGSLP_RESET              0x00000000            /*      Reset Value for SEQTRGSLP  */
+#define REG_AFE_SEQTRGSLP                    0x0000211C            /*  AFE Sequencer Trigger Sleep */
+#define REG_AFE_LPDACDAT0_RESET              0x00000000            /*      Reset Value for LPDACDAT0  */
+#define REG_AFE_LPDACDAT0                    0x00002120            /*  AFE LPDAC Data-out */
+#define REG_AFE_LPDACSW0_RESET               0x00000000            /*      Reset Value for LPDACSW0  */
+#define REG_AFE_LPDACSW0                     0x00002124            /*  AFE LPDAC0 Switch Control */
+#define REG_AFE_LPDACCON0_RESET              0x00000002            /*      Reset Value for LPDACCON0  */
+#define REG_AFE_LPDACCON0                    0x00002128            /*  AFE LPDAC Control Bits */
+#define REG_AFE_LPDACDAT1                    0x0000212C            /*  AFE Low Power DAC1 data register */
+#define REG_AFE_LPDACSW1                     0x00002130            /*  AFE Control register for switches to LPDAC1 */
+#define REG_AFE_LPDACCON1                    0x00002134            /*  AFE ULP_DACCON1 */
+#define REG_AFE_DSWFULLCON_RESET             0x00000000            /*      Reset Value for DSWFULLCON  */
+#define REG_AFE_DSWFULLCON                   0x00002150            /*  AFE Switch Matrix Full Configuration (D) */
+#define REG_AFE_NSWFULLCON_RESET             0x00000000            /*      Reset Value for NSWFULLCON  */
+#define REG_AFE_NSWFULLCON                   0x00002154            /*  AFE Switch Matrix Full Configuration (N) */
+#define REG_AFE_PSWFULLCON_RESET             0x00000000            /*      Reset Value for PSWFULLCON  */
+#define REG_AFE_PSWFULLCON                   0x00002158            /*  AFE Switch Matrix Full Configuration (P) */
+#define REG_AFE_TSWFULLCON_RESET             0x00000000            /*      Reset Value for TSWFULLCON  */
+#define REG_AFE_TSWFULLCON                   0x0000215C            /*  AFE Switch Matrix Full Configuration (T) */
+#define REG_AFE_TEMPSENS_RESET               0x00000000            /*      Reset Value for TEMPSENS  */
+#define REG_AFE_TEMPSENS                     0x00002174            /*  AFE Temp Sensor Configuration */
+#define REG_AFE_BUFSENCON_RESET              0x00000037            /*      Reset Value for BUFSENCON  */
+#define REG_AFE_BUFSENCON                    0x00002180            /*  AFE HP and LP Buffer Control */
+#define REG_AFE_ADCCON_RESET                 0x00000000            /*      Reset Value for ADCCON  */
+#define REG_AFE_ADCCON                       0x000021A8            /*  AFE ADC Configuration */
+#define REG_AFE_DSWSTA_RESET                 0x00000000            /*      Reset Value for DSWSTA  */
+#define REG_AFE_DSWSTA                       0x000021B0            /*  AFE Switch Matrix Status (D) */
+#define REG_AFE_PSWSTA_RESET                 0x00006000            /*      Reset Value for PSWSTA  */
+#define REG_AFE_PSWSTA                       0x000021B4            /*  AFE Switch Matrix Status (P) */
+#define REG_AFE_NSWSTA_RESET                 0x00000C00            /*      Reset Value for NSWSTA  */
+#define REG_AFE_NSWSTA                       0x000021B8            /*  AFE Switch Matrix Status (N) */
+#define REG_AFE_TSWSTA_RESET                 0x00000000            /*      Reset Value for TSWSTA  */
+#define REG_AFE_TSWSTA                       0x000021BC            /*  AFE Switch Matrix Status (T) */
+#define REG_AFE_STATSVAR_RESET               0x00000000            /*      Reset Value for STATSVAR  */
+#define REG_AFE_STATSVAR                     0x000021C0            /*  AFE Variance Output */
+#define REG_AFE_STATSCON_RESET               0x00000000            /*      Reset Value for STATSCON  */
+#define REG_AFE_STATSCON                     0x000021C4            /*  AFE Statistics Control */
+#define REG_AFE_STATSMEAN_RESET              0x00000000            /*      Reset Value for STATSMEAN  */
+#define REG_AFE_STATSMEAN                    0x000021C8            /*  AFE Statistics Mean Output */
+#define REG_AFE_SEQ0INFO_RESET               0x00000000            /*      Reset Value for SEQ0INFO  */
+#define REG_AFE_SEQ0INFO                     0x000021CC            /*  AFE Sequence 0 Info */
+#define REG_AFE_SEQ2INFO_RESET               0x00000000            /*      Reset Value for SEQ2INFO  */
+#define REG_AFE_SEQ2INFO                     0x000021D0            /*  AFE Sequence 2 Info */
+#define REG_AFE_CMDFIFOWADDR_RESET           0x00000000            /*      Reset Value for CMDFIFOWADDR  */
+#define REG_AFE_CMDFIFOWADDR                 0x000021D4            /*  AFE Command FIFO Write Address */
+#define REG_AFE_CMDDATACON_RESET             0x00000410            /*      Reset Value for CMDDATACON  */
+#define REG_AFE_CMDDATACON                   0x000021D8            /*  AFE Command Data Control */
+#define REG_AFE_DATAFIFOTHRES_RESET          0x00000000            /*      Reset Value for DATAFIFOTHRES  */
+#define REG_AFE_DATAFIFOTHRES                0x000021E0            /*  AFE Data FIFO Threshold */
+#define REG_AFE_SEQ3INFO_RESET               0x00000000            /*      Reset Value for SEQ3INFO  */
+#define REG_AFE_SEQ3INFO                     0x000021E4            /*  AFE Sequence 3 Info */
+#define REG_AFE_SEQ1INFO_RESET               0x00000000            /*      Reset Value for SEQ1INFO  */
+#define REG_AFE_SEQ1INFO                     0x000021E8            /*  AFE Sequence 1 Info */
+#define REG_AFE_REPEATADCCNV_RESET           0x00000160            /*      Reset Value for REPEATADCCNV  */
+#define REG_AFE_REPEATADCCNV                 0x000021F0            /*  AFE REPEAT ADC Conversions */
+#define REG_AFE_FIFOCNTSTA_RESET             0x00000000            /*      Reset Value for FIFOCNTSTA  */
+#define REG_AFE_FIFOCNTSTA                   0x00002200            /*  AFE CMD and DATA FIFO INTERNAL DATA COUNT */
+#define REG_AFE_CALDATLOCK_RESET             0x00000000            /*      Reset Value for CALDATLOCK  */
+#define REG_AFE_CALDATLOCK                   0x00002230            /*  AFE Calibration Data Lock */
+#define REG_AFE_ADCOFFSETHSTIA_RESET         0x00000000            /*      Reset Value for ADCOFFSETHSTIA  */
+#define REG_AFE_ADCOFFSETHSTIA               0x00002234            /*  AFE ADC Offset Calibration High Speed TIA Channel */
+#define REG_AFE_ADCGAINTEMPSENS0_RESET       0x00004000            /*      Reset Value for ADCGAINTEMPSENS0  */
+#define REG_AFE_ADCGAINTEMPSENS0             0x00002238            /*  AFE ADC Gain Calibration Temp Sensor Channel */
+#define REG_AFE_ADCOFFSETTEMPSENS0_RESET     0x00000000            /*      Reset Value for ADCOFFSETTEMPSENS0  */
+#define REG_AFE_ADCOFFSETTEMPSENS0           0x0000223C            /*  AFE ADC Offset Calibration Temp Sensor Channel 0 */
+#define REG_AFE_ADCGAINGN1_RESET             0x00004000            /*      Reset Value for ADCGAINGN1  */
+#define REG_AFE_ADCGAINGN1                   0x00002240            /*  AFE ADCPGAGN1: ADC Gain Calibration Auxiliary Input Channel */
+#define REG_AFE_ADCOFFSETGN1_RESET           0x00000000            /*      Reset Value for ADCOFFSETGN1  */
+#define REG_AFE_ADCOFFSETGN1                 0x00002244            /*  AFE ADC Offset Calibration Auxiliary Channel (PGA Gain=1) */
+#define REG_AFE_DACGAIN_RESET                0x00000800            /*      Reset Value for DACGAIN  */
+#define REG_AFE_DACGAIN                      0x00002260            /*  AFE DACGAIN */
+#define REG_AFE_DACOFFSETATTEN_RESET         0x00000000            /*      Reset Value for DACOFFSETATTEN  */
+#define REG_AFE_DACOFFSETATTEN               0x00002264            /*  AFE DAC Offset with Attenuator Enabled (LP Mode) */
+#define REG_AFE_DACOFFSET_RESET              0x00000000            /*      Reset Value for DACOFFSET  */
+#define REG_AFE_DACOFFSET                    0x00002268            /*  AFE DAC Offset with Attenuator Disabled (LP Mode) */
+#define REG_AFE_ADCGAINGN1P5_RESET           0x00004000            /*      Reset Value for ADCGAINGN1P5  */
+#define REG_AFE_ADCGAINGN1P5                 0x00002270            /*  AFE ADC Gain Calibration Auxiliary Input Channel (PGA Gain=1.5) */
+#define REG_AFE_ADCGAINGN2_RESET             0x00004000            /*      Reset Value for ADCGAINGN2  */
+#define REG_AFE_ADCGAINGN2                   0x00002274            /*  AFE ADC Gain Calibration Auxiliary Input Channel (PGA Gain=2) */
+#define REG_AFE_ADCGAINGN4_RESET             0x00004000            /*      Reset Value for ADCGAINGN4  */
+#define REG_AFE_ADCGAINGN4                   0x00002278            /*  AFE ADC Gain Calibration Auxiliary Input Channel (PGA Gain=4) */
+#define REG_AFE_ADCPGAOFFSETCANCEL_RESET     0x00000000            /*      Reset Value for ADCPGAOFFSETCANCEL  */
+#define REG_AFE_ADCPGAOFFSETCANCEL           0x00002280            /*  AFE ADC Offset Cancellation (Optional) */
+#define REG_AFE_ADCGNHSTIA_RESET             0x00004000            /*      Reset Value for ADCGNHSTIA  */
+#define REG_AFE_ADCGNHSTIA                   0x00002284            /*  AFE ADC Gain Calibration for HS TIA Channel */
+#define REG_AFE_ADCOFFSETLPTIA0_RESET        0x00000000            /*      Reset Value for ADCOFFSETLPTIA0  */
+#define REG_AFE_ADCOFFSETLPTIA0              0x00002288            /*  AFE ADC Offset Calibration ULP-TIA0 Channel */
+#define REG_AFE_ADCGNLPTIA0_RESET            0x00004000            /*      Reset Value for ADCGNLPTIA0  */
+#define REG_AFE_ADCGNLPTIA0                  0x0000228C            /*  AFE ADC GAIN Calibration for LP TIA0 Channel */
+#define REG_AFE_ADCPGAGN4OFCAL_RESET         0x00004000            /*      Reset Value for ADCPGAGN4OFCAL  */
+#define REG_AFE_ADCPGAGN4OFCAL               0x00002294            /*  AFE ADC Gain Calibration with DC Cancellation(PGA G=4) */
+#define REG_AFE_ADCGAINGN9_RESET             0x00004000            /*      Reset Value for ADCGAINGN9  */
+#define REG_AFE_ADCGAINGN9                   0x00002298            /*  AFE ADC Gain Calibration Auxiliary Input Channel (PGA Gain=9) */
+#define REG_AFE_ADCOFFSETEMPSENS1_RESET      0x00000000            /*      Reset Value for ADCOFFSETEMPSENS1  */
+#define REG_AFE_ADCOFFSETEMPSENS1            0x000022A8            /*  AFE ADC Offset Calibration  Temp Sensor Channel 1 */
+#define REG_AFE_ADCGAINDIOTEMPSENS_RESET     0x00004000            /*      Reset Value for ADCGAINDIOTEMPSENS  */
+#define REG_AFE_ADCGAINDIOTEMPSENS           0x000022AC            /*  AFE ADC Gain Calibration Diode Temperature Sensor Channel */
+#define REG_AFE_DACOFFSETATTENHP_RESET       0x00000000            /*      Reset Value for DACOFFSETATTENHP  */
+#define REG_AFE_DACOFFSETATTENHP             0x000022B8            /*  AFE DAC Offset with Attenuator Enabled (HP Mode) */
+#define REG_AFE_DACOFFSETHP_RESET            0x00000000            /*      Reset Value for DACOFFSETHP  */
+#define REG_AFE_DACOFFSETHP                  0x000022BC            /*  AFE DAC Offset with Attenuator Disabled (HP Mode) */
+#define REG_AFE_ADCGNLPTIA1_RESET            0x00004000            /*      Reset Value for ADCGNLPTIA1  */
+#define REG_AFE_ADCOFFSETLPTIA1              0x000022C0            /*  AFE ADC Offset Calibration ULP-TIA0 Channel */
+#define REG_AFE_ADCGNLPTIA1                  0x000022C4            /*  AFE ADC GAIN Calibration for LP TIA1 Channel */
+#define REG_AFE_ADCOFFSETGN2_RESET           0x00000000            /*      Reset Value for ADCOFFSETGN2  */
+#define REG_AFE_ADCOFFSETGN2                 0x000022C8            /*  AFE Offset Calibration Auxiliary Channel (PGA Gain =2) */
+#define REG_AFE_ADCOFFSETGN1P5_RESET         0x00000000            /*      Reset Value for ADCOFFSETGN1P5  */
+#define REG_AFE_ADCOFFSETGN1P5               0x000022CC            /*  AFE Offset Calibration Auxiliary Channel (PGA Gain =1.5) */
+#define REG_AFE_ADCOFFSETGN9_RESET           0x00000000            /*      Reset Value for ADCOFFSETGN9  */
+#define REG_AFE_ADCOFFSETGN9                 0x000022D0            /*  AFE Offset Calibration Auxiliary Channel (PGA Gain =9) */
+#define REG_AFE_ADCOFFSETGN4_RESET           0x00000000            /*      Reset Value for ADCOFFSETGN4  */
+#define REG_AFE_ADCOFFSETGN4                 0x000022D4            /*  AFE Offset Calibration Auxiliary Channel (PGA Gain =4) */
+#define REG_AFE_PMBW_RESET                   0x00088800            /*      Reset Value for PMBW  */
+#define REG_AFE_PMBW                         0x000022F0            /*  AFE Power Mode Configuration */
+#define REG_AFE_SWMUX_RESET                 0x00000000            /*      Reset Value for SWMUX  */
+#define REG_AFE_SWMUX                       0x0000235C            /*  AFE Switch Mux for ECG */
+#define REG_AFE_AFE_TEMPSEN_DIO_RESET        0x00020000            /*      Reset Value for AFE_TEMPSEN_DIO  */
+#define REG_AFE_AFE_TEMPSEN_DIO              0x00002374            /*  AFE AFE_TEMPSEN_DIO */
+#define REG_AFE_ADCBUFCON_RESET              0x005F3D00            /*      Reset Value for ADCBUFCON  */
+#define REG_AFE_ADCBUFCON                    0x0000238C            /*  AFE Configure ADC Input Buffer */
+
+/* ============================================================================================================================
+        AFE Register BitMasks, Positions & Enumerations 
+   ============================================================================================================================ */
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_AFECON                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_AFECON_DACBUFEN             21            /*  Enable DC DAC Buffer */
+#define BITP_AFE_AFECON_DACREFEN             20            /*  High Speed DAC Reference Enable */
+#define BITP_AFE_AFECON_ALDOILIMITEN         19            /*  Analog LDO Current Limiting Enable */
+#define BITP_AFE_AFECON_SINC2EN              16            /*  ADC Output 50/60Hz Filter Enable */
+#define BITP_AFE_AFECON_DFTEN                15            /*  DFT Hardware Accelerator Enable */
+#define BITP_AFE_AFECON_WAVEGENEN            14            /*  Waveform Generator Enable */
+#define BITP_AFE_AFECON_TEMPCONVEN           13            /*  ADC Temp Sensor Convert Enable */
+#define BITP_AFE_AFECON_TEMPSENSEN           12            /*  ADC Temperature Sensor Channel Enable */
+#define BITP_AFE_AFECON_TIAEN                11            /*  High Power TIA Enable */
+#define BITP_AFE_AFECON_INAMPEN              10            /*  Enable Excitation Amplifier */
+#define BITP_AFE_AFECON_EXBUFEN               9            /*  Enable Excitation Buffer */
+#define BITP_AFE_AFECON_ADCCONVEN             8            /*  ADC Conversion Start Enable */
+#define BITP_AFE_AFECON_ADCEN                 7            /*  ADC Power Enable */
+#define BITP_AFE_AFECON_DACEN                 6            /*  High Power DAC Enable */
+#define BITP_AFE_AFECON_HPREFDIS              5            /*  Disable High Power Reference */
+#define BITM_AFE_AFECON_DACBUFEN             0x00200000    /*  Enable DC DAC Buffer */
+#define BITM_AFE_AFECON_DACREFEN             0x00100000    /*  High Speed DAC Reference Enable */
+#define BITM_AFE_AFECON_ALDOILIMITEN         0x00080000    /*  Analog LDO Current Limiting Enable */
+#define BITM_AFE_AFECON_SINC2EN              0x00010000    /*  ADC Output 50/60Hz Filter Enable */
+#define BITM_AFE_AFECON_DFTEN                0x00008000    /*  DFT Hardware Accelerator Enable */
+#define BITM_AFE_AFECON_WAVEGENEN            0x00004000    /*  Waveform Generator Enable */
+#define BITM_AFE_AFECON_TEMPCONVEN           0x00002000    /*  ADC Temp Sensor Convert Enable */
+#define BITM_AFE_AFECON_TEMPSENSEN           0x00001000    /*  ADC Temperature Sensor Channel Enable */
+#define BITM_AFE_AFECON_TIAEN                0x00000800    /*  High Power TIA Enable */
+#define BITM_AFE_AFECON_INAMPEN              0x00000400    /*  Enable Excitation Amplifier */
+#define BITM_AFE_AFECON_EXBUFEN              0x00000200    /*  Enable Excitation Buffer */
+#define BITM_AFE_AFECON_ADCCONVEN            0x00000100    /*  ADC Conversion Start Enable */
+#define BITM_AFE_AFECON_ADCEN                0x00000080    /*  ADC Power Enable */
+#define BITM_AFE_AFECON_DACEN                0x00000040    /*  High Power DAC Enable */
+#define BITM_AFE_AFECON_HPREFDIS             0x00000020    /*  Disable High Power Reference */
+#define ENUM_AFE_AFECON_OFF                  0x00000000            /*  DACEN: High Power DAC Disabled */
+#define ENUM_AFE_AFECON_ON                   0x00000040            /*  DACEN: High Power DAC Enabled */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_SEQCON                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_SEQCON_SEQWRTMR              8            /*  Timer for Sequencer Write Commands */
+#define BITP_AFE_SEQCON_SEQHALT               4            /*  Halt Seq */
+#define BITP_AFE_SEQCON_SEQHALTFIFOEMPTY      1            /*  Halt Sequencer If Empty */
+#define BITP_AFE_SEQCON_SEQEN                 0            /*  Enable Sequencer */
+#define BITM_AFE_SEQCON_SEQWRTMR             0x0000FF00    /*  Timer for Sequencer Write Commands */
+#define BITM_AFE_SEQCON_SEQHALT              0x00000010    /*  Halt Seq */
+#define BITM_AFE_SEQCON_SEQHALTFIFOEMPTY     0x00000002    /*  Halt Sequencer If Empty */
+#define BITM_AFE_SEQCON_SEQEN                0x00000001    /*  Enable Sequencer */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_FIFOCON                          Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_FIFOCON_DATAFIFOSRCSEL      13            /*  Selects the Source for the Data FIFO. */
+#define BITP_AFE_FIFOCON_DATAFIFOEN          11            /*  Data FIFO Enable. */
+#define BITM_AFE_FIFOCON_DATAFIFOSRCSEL      0x0000E000    /*  Selects the Source for the Data FIFO. */
+#define BITM_AFE_FIFOCON_DATAFIFOEN          0x00000800    /*  Data FIFO Enable. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_SWCON                            Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_SWCON_T11CON                19            /*  Control of T[11] */
+#define BITP_AFE_SWCON_T10CON                18            /*  Control of T[10] */
+#define BITP_AFE_SWCON_T9CON                 17            /*  Control of T[9] */
+#define BITP_AFE_SWCON_SWSOURCESEL           16            /*  Switch Control Select */
+#define BITP_AFE_SWCON_TMUXCON               12            /*  Control of T Switch MUX. */
+#define BITP_AFE_SWCON_NMUXCON                8            /*  Control of N Switch MUX */
+#define BITP_AFE_SWCON_PMUXCON                4            /*  Control of P Switch MUX */
+#define BITP_AFE_SWCON_DMUXCON                0            /*  Control of D Switch MUX */
+#define BITM_AFE_SWCON_T11CON                0x00080000    /*  Control of T[11] */
+#define BITM_AFE_SWCON_T10CON                0x00040000    /*  Control of T[10] */
+#define BITM_AFE_SWCON_T9CON                 0x00020000    /*  Control of T[9] */
+#define BITM_AFE_SWCON_SWSOURCESEL           0x00010000    /*  Switch Control Select */
+#define BITM_AFE_SWCON_TMUXCON               0x0000F000    /*  Control of T Switch MUX. */
+#define BITM_AFE_SWCON_NMUXCON               0x00000F00    /*  Control of N Switch MUX */
+#define BITM_AFE_SWCON_PMUXCON               0x000000F0    /*  Control of P Switch MUX */
+#define BITM_AFE_SWCON_DMUXCON               0x0000000F    /*  Control of D Switch MUX */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_HSDACCON                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_HSDACCON_INAMPGNMDE         12            /*  Excitation Amplifier Gain Control */
+#define BITP_AFE_HSDACCON_RATE                1            /*  DAC Update Rate */
+#define BITP_AFE_HSDACCON_ATTENEN             0            /*  PGA Stage Gain Attenuation */
+#define BITM_AFE_HSDACCON_INAMPGNMDE         0x00001000    /*  Excitation Amplifier Gain Control */
+#define BITM_AFE_HSDACCON_RATE               0x000001FE    /*  DAC Update Rate */
+#define BITM_AFE_HSDACCON_ATTENEN            0x00000001    /*  PGA Stage Gain Attenuation */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_WGCON                            Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_WGCON_DACGAINCAL             5            /*  Bypass DAC Gain */
+#define BITP_AFE_WGCON_DACOFFSETCAL           4            /*  Bypass DAC Offset */
+#define BITP_AFE_WGCON_TYPESEL                1            /*  Selects the Type of Waveform */
+#define BITP_AFE_WGCON_TRAPRSTEN              0            /*  Resets the Trapezoid Waveform Generator */
+#define BITM_AFE_WGCON_DACGAINCAL            0x00000020    /*  Bypass DAC Gain */
+#define BITM_AFE_WGCON_DACOFFSETCAL          0x00000010    /*  Bypass DAC Offset */
+#define BITM_AFE_WGCON_TYPESEL               0x00000006    /*  Selects the Type of Waveform */
+#define BITM_AFE_WGCON_TRAPRSTEN             0x00000001    /*  Resets the Trapezoid Waveform Generator */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_WGDCLEVEL1                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_WGDCLEVEL1_TRAPDCLEVEL1      0            /*  DC Level 1 Value for Trapezoid Waveform Generation */
+#define BITM_AFE_WGDCLEVEL1_TRAPDCLEVEL1     0x00000FFF    /*  DC Level 1 Value for Trapezoid Waveform Generation */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_WGDCLEVEL2                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_WGDCLEVEL2_TRAPDCLEVEL2      0            /*  DC Level 2 Value for Trapezoid Waveform Generation */
+#define BITM_AFE_WGDCLEVEL2_TRAPDCLEVEL2     0x00000FFF    /*  DC Level 2 Value for Trapezoid Waveform Generation */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_WGDELAY1                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_WGDELAY1_DELAY1              0            /*  Delay 1 Value for Trapezoid Waveform Generation */
+#define BITM_AFE_WGDELAY1_DELAY1             0x000FFFFF    /*  Delay 1 Value for Trapezoid Waveform Generation */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_WGSLOPE1                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_WGSLOPE1_SLOPE1              0            /*  Slope 1 Value for Trapezoid Waveform Generation */
+#define BITM_AFE_WGSLOPE1_SLOPE1             0x000FFFFF    /*  Slope 1 Value for Trapezoid Waveform Generation */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_WGDELAY2                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_WGDELAY2_DELAY2              0            /*  Delay 2 Value for Trapezoid Waveform Generation */
+#define BITM_AFE_WGDELAY2_DELAY2             0x000FFFFF    /*  Delay 2 Value for Trapezoid Waveform Generation */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_WGSLOPE2                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_WGSLOPE2_SLOPE2              0            /*  Slope 2 Value for Trapezoid Waveform Generation. */
+#define BITM_AFE_WGSLOPE2_SLOPE2             0x000FFFFF    /*  Slope 2 Value for Trapezoid Waveform Generation. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_WGFCW                            Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_WGFCW_SINEFCW                0            /*  Sinusoid Generator Frequency Control Word */
+#define BITM_AFE_WGFCW_SINEFCW               0x00FFFFFF    /*  Sinusoid Generator Frequency Control Word */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_WGPHASE                          Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_WGPHASE_SINEOFFSET           0            /*  Sinusoid Phase Offset */
+#define BITM_AFE_WGPHASE_SINEOFFSET          0x000FFFFF    /*  Sinusoid Phase Offset */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_WGOFFSET                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_WGOFFSET_SINEOFFSET          0            /*  Sinusoid Offset */
+#define BITM_AFE_WGOFFSET_SINEOFFSET         0x00000FFF    /*  Sinusoid Offset */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_WGAMPLITUDE                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_WGAMPLITUDE_SINEAMPLITUDE    0            /*  Sinusoid Amplitude */
+#define BITM_AFE_WGAMPLITUDE_SINEAMPLITUDE   0x000007FF    /*  Sinusoid Amplitude */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCFILTERCON                     Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCFILTERCON_AVRGNUM        14            /*  Number of Samples Averaged */
+#define BITP_AFE_ADCFILTERCON_SINC3OSR       12            /*  SINC3 OSR */
+#define BITP_AFE_ADCFILTERCON_SINC2OSR        8            /*  SINC2 OSR */
+#define BITP_AFE_ADCFILTERCON_AVRGEN          7            /*  Average Function Enable */
+#define BITP_AFE_ADCFILTERCON_SINC3BYP        6            /*  SINC3 Filter Bypass */
+#define BITP_AFE_ADCFILTERCON_LPFBYPEN        4            /*  50/60Hz Low Pass Filter */
+#define BITP_AFE_ADCFILTERCON_ADCCLK          0            /*  ADC Data Rate */
+#define BITM_AFE_ADCFILTERCON_AVRGNUM        0x0000C000    /*  Number of Samples Averaged */
+#define BITM_AFE_ADCFILTERCON_SINC3OSR       0x00003000    /*  SINC3 OSR */
+#define BITM_AFE_ADCFILTERCON_SINC2OSR       0x00000F00    /*  SINC2 OSR */
+#define BITM_AFE_ADCFILTERCON_AVRGEN         0x00000080    /*  Average Function Enable */
+#define BITM_AFE_ADCFILTERCON_SINC3BYP       0x00000040    /*  SINC3 Filter Bypass */
+#define BITM_AFE_ADCFILTERCON_LPFBYPEN       0x00000010    /*  50/60Hz Low Pass Filter */
+#define BITM_AFE_ADCFILTERCON_ADCCLK         0x00000001    /*  ADC Data Rate */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_HSDACDAT                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_HSDACDAT_DACDAT              0            /*  DAC Code */
+#define BITM_AFE_HSDACDAT_DACDAT             0x00000FFF    /*  DAC Code */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_LPREFBUFCON                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_LPREFBUFCON_BOOSTCURRENT     2            /*  Set: Drive 2 Dac ;Unset Drive 1 Dac, and Save Power */
+#define BITP_AFE_LPREFBUFCON_LPBUF2P5DIS      1            /*  Low Power Bandgap's Output Buffer */
+#define BITP_AFE_LPREFBUFCON_LPREFDIS         0            /*  Set This Bit Will Power Down Low Power Bandgap */
+#define BITM_AFE_LPREFBUFCON_BOOSTCURRENT    0x00000004    /*  Set: Drive 2 Dac ;Unset Drive 1 Dac, and Save Power */
+#define BITM_AFE_LPREFBUFCON_LPBUF2P5DIS     0x00000002    /*  Low Power Bandgap's Output Buffer */
+#define BITM_AFE_LPREFBUFCON_LPREFDIS        0x00000001    /*  Set This Bit Will Power Down Low Power Bandgap */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_SYNCEXTDEVICE                    Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_SYNCEXTDEVICE_SYNC           0            /*  As Output Data of GPIO */
+#define BITM_AFE_SYNCEXTDEVICE_SYNC          0x000000FF    /*  As Output Data of GPIO */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_SEQCRC                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_SEQCRC_CRC                   0            /*  Sequencer Command CRC Value. */
+#define BITM_AFE_SEQCRC_CRC                  0x000000FF    /*  Sequencer Command CRC Value. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_SEQCNT                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_SEQCNT_COUNT                 0            /*  Sequencer Command Count */
+#define BITM_AFE_SEQCNT_COUNT                0x0000FFFF    /*  Sequencer Command Count */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_SEQTIMEOUT                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_SEQTIMEOUT_TIMEOUT           0            /*  Current Value of the Sequencer Timeout Counter. */
+#define BITM_AFE_SEQTIMEOUT_TIMEOUT          0x3FFFFFFF    /*  Current Value of the Sequencer Timeout Counter. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_DATAFIFORD                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_DATAFIFORD_DATAFIFOOUT       0            /*  Data FIFO Read */
+#define BITM_AFE_DATAFIFORD_DATAFIFOOUT      0x0000FFFF    /*  Data FIFO Read */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_CMDFIFOWRITE                     Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_CMDFIFOWRITE_CMDFIFOIN       0            /*  Command FIFO Write. */
+#define BITM_AFE_CMDFIFOWRITE_CMDFIFOIN      0xFFFFFFFF    /*  Command FIFO Write. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCDAT                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCDAT_DATA                  0            /*  ADC Result */
+#define BITM_AFE_ADCDAT_DATA                 0x0000FFFF    /*  ADC Result */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_DFTREAL                          Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_DFTREAL_DATA                 0            /*  DFT Real */
+#define BITM_AFE_DFTREAL_DATA                0x0003FFFF    /*  DFT Real */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_DFTIMAG                          Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_DFTIMAG_DATA                 0            /*  DFT Imaginary */
+#define BITM_AFE_DFTIMAG_DATA                0x0003FFFF    /*  DFT Imaginary */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_SINC2DAT                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_SINC2DAT_DATA                0            /*  LPF Result */
+#define BITM_AFE_SINC2DAT_DATA               0x0000FFFF    /*  LPF Result */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_TEMPSENSDAT                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_TEMPSENSDAT_DATA             0            /*  Temp Sensor */
+#define BITM_AFE_TEMPSENSDAT_DATA            0x0000FFFF    /*  Temp Sensor */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_AFEGENINTSTA                     Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_AFEGENINTSTA_CUSTOMIRQ3      3            /*  Custom IRQ 3. */
+#define BITP_AFE_AFEGENINTSTA_CUSTOMIRQ2      2            /*  Custom IRQ 2 */
+#define BITP_AFE_AFEGENINTSTA_CUSTOMIRQ1      1            /*  Custom IRQ 1. */
+#define BITP_AFE_AFEGENINTSTA_CUSTOMIRQ0      0            /*  Custom IRQ 0 */
+#define BITM_AFE_AFEGENINTSTA_CUSTOMIRQ3     0x00000008    /*  Custom IRQ 3. */
+#define BITM_AFE_AFEGENINTSTA_CUSTOMIRQ2     0x00000004    /*  Custom IRQ 2 */
+#define BITM_AFE_AFEGENINTSTA_CUSTOMIRQ1     0x00000002    /*  Custom IRQ 1. */
+#define BITM_AFE_AFEGENINTSTA_CUSTOMIRQ0     0x00000001    /*  Custom IRQ 0 */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCMIN                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCMIN_MINVAL                0            /*  ADC Minimum Value Threshold */
+#define BITM_AFE_ADCMIN_MINVAL               0x0000FFFF    /*  ADC Minimum Value Threshold */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCMINSM                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCMINSM_MINCLRVAL           0            /*  ADCMIN Hysteresis Value */
+#define BITM_AFE_ADCMINSM_MINCLRVAL          0x0000FFFF    /*  ADCMIN Hysteresis Value */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCMAX                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCMAX_MAXVAL                0            /*  ADC Max Threshold */
+#define BITM_AFE_ADCMAX_MAXVAL               0x0000FFFF    /*  ADC Max Threshold */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCMAXSMEN                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCMAXSMEN_MAXSWEN           0            /*  ADCMAX Hysteresis Value */
+#define BITM_AFE_ADCMAXSMEN_MAXSWEN          0x0000FFFF    /*  ADCMAX Hysteresis Value */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCDELTA                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCDELTA_DELTAVAL            0            /*  ADCDAT Code Differences Limit Option */
+#define BITM_AFE_ADCDELTA_DELTAVAL           0x0000FFFF    /*  ADCDAT Code Differences Limit Option */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_HPOSCCON                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_HPOSCCON_CLK32MHZEN          2            /*  16M/32M Output Selector Signal. */
+#define BITM_AFE_HPOSCCON_CLK32MHZEN         0x00000004    /*  16M/32M Output Selector Signal. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_DFTCON                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_DFTCON_DFTINSEL             20            /*  DFT Input Select */
+#define BITP_AFE_DFTCON_DFTNUM                4            /*  ADC Samples Used */
+#define BITP_AFE_DFTCON_HANNINGEN             0            /*  Hanning Window Enable */
+#define BITM_AFE_DFTCON_DFTINSEL             0x00300000    /*  DFT Input Select */
+#define BITM_AFE_DFTCON_DFTNUM               0x000000F0    /*  ADC Samples Used */
+#define BITM_AFE_DFTCON_HANNINGEN            0x00000001    /*  Hanning Window Enable */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_LPTIASW1                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_LPTIASW1_TIABIASSEL         13            /*  TIA SW13 Control. Active High */
+#define BITP_AFE_LPTIASW1_PABIASSEL          12            /*  TIA SW12 Control. Active High */
+#define BITP_AFE_LPTIASW1_TIASWCON            0            /*  TIA SW[11:0] Control */
+#define BITM_AFE_LPTIASW1_TIABIASSEL         (_ADI_MSK_3(0x00002000,0x00002000UL, uint32_t  ))    /*  TIA SW13 Control. Active High */
+#define BITM_AFE_LPTIASW1_PABIASSEL          (_ADI_MSK_3(0x00001000,0x00001000UL, uint32_t  ))    /*  TIA SW12 Control. Active High */
+#define BITM_AFE_LPTIASW1_TIASWCON           (_ADI_MSK_3(0x00000FFF,0x00000FFFUL, uint32_t  ))    /*  TIA SW[11:0] Control */
+#define ENUM_AFE_LPTIASW1_CAPA_LP            (_ADI_MSK_3(0x00000014,0x00000014UL, uint32_t  ))    /*  TIASWCON: CAPA test with LP TIA */
+#define ENUM_AFE_LPTIASW1_NORM               (_ADI_MSK_3(0x0000002C,0x0000002CUL, uint32_t  ))    /*  TIASWCON: Normal work mode */
+#define ENUM_AFE_LPTIASW1_DIO                (_ADI_MSK_3(0x0000002D,0x0000002DUL, uint32_t  ))    /*  TIASWCON: Normal work mode with back-back diode enabled. */
+#define ENUM_AFE_LPTIASW1_SHORTSW            (_ADI_MSK_3(0x0000002E,0x0000002EUL, uint32_t  ))    /*  TIASWCON: Work mode with short switch protection */
+#define ENUM_AFE_LPTIASW1_LOWNOISE           (_ADI_MSK_3(0x0000006C,0x0000006CUL, uint32_t  ))    /*  TIASWCON: Work mode, vzero-vbias=0. */
+#define ENUM_AFE_LPTIASW1_CAPA_RAMP_H        (_ADI_MSK_3(0x00000094,0x00000094UL, uint32_t  ))    /*  TIASWCON: CAPA test or Ramp test with HP TIA */
+#define ENUM_AFE_LPTIASW1_BUFDIS             (_ADI_MSK_3(0x00000180,0x00000180UL, uint32_t  ))    /*  TIASWCON: Set PA/TIA as unity gain buffer. */
+#define ENUM_AFE_LPTIASW1_BUFEN              (_ADI_MSK_3(0x000001A4,0x000001A4UL, uint32_t  ))    /*  TIASWCON: Set PA/TIA as unity gain buffer. Connect amp's output to CE1 & RC11. */
+#define ENUM_AFE_LPTIASW1_TWOLEAD            (_ADI_MSK_3(0x0000042C,0x0000042CUL, uint32_t  ))    /*  TIASWCON: Two lead sensor, set PA as unity gain buffer. */
+#define ENUM_AFE_LPTIASW1_BUFEN2             (_ADI_MSK_3(0x000004A4,0x000004A4UL, uint32_t  ))    /*  TIASWCON: Set PA/TIA as unity gain buffer. */
+#define ENUM_AFE_LPTIASW1_SESHORTRE          (_ADI_MSK_3(0x00000800,0x00000800UL, uint32_t  ))    /*  TIASWCON: Close SW11 - Short SE1 to RE1, */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_LPTIASW0                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_LPTIASW0_RECAL              15            /*  TIA SW15 Control. Active High */
+#define BITP_AFE_LPTIASW0_VZEROSHARE         14            /*  TIA SW14 Control. Active High */
+#define BITP_AFE_LPTIASW0_TIABIASSEL         13            /*  TIA SW13 Control. Active High */
+#define BITP_AFE_LPTIASW0_PABIASSEL          12            /*  TIA SW12 Control. Active High */
+#define BITP_AFE_LPTIASW0_TIASWCON            0            /*  TIA SW[11:0] Control */
+#define BITM_AFE_LPTIASW0_RECAL              0x00008000    /*  TIA SW15 Control. Active High */
+#define BITM_AFE_LPTIASW0_VZEROSHARE         0x00004000    /*  TIA SW14 Control. Active High */
+#define BITM_AFE_LPTIASW0_TIABIASSEL         0x00002000    /*  TIA SW13 Control. Active High */
+#define BITM_AFE_LPTIASW0_PABIASSEL          0x00001000    /*  TIA SW12 Control. Active High */
+#define BITM_AFE_LPTIASW0_TIASWCON           0x00000FFF    /*  TIA SW[11:0] Control */
+#define ENUM_AFE_LPTIASW0_11                 0x00000014            /*  TIASWCON: CAPA test with LP TIA */
+#define ENUM_AFE_LPTIASW0_NORM               0x0000002C            /*  TIASWCON: Normal work mode */
+#define ENUM_AFE_LPTIASW0_DIO                0x0000002D            /*  TIASWCON: Normal work mode with back-back diode enabled. */
+#define ENUM_AFE_LPTIASW0_SHORTSW            0x0000002E            /*  TIASWCON: Work mode with short switch protection */
+#define ENUM_AFE_LPTIASW0_LOWNOISE           0x0000006C            /*  TIASWCON: Work mode, vzero-vbias=0. */
+#define ENUM_AFE_LPTIASW0_1                  0x00000094            /*  TIASWCON: CAPA test or Ramp test with HP TIA */
+#define ENUM_AFE_LPTIASW0_BUFDIS             0x00000180            /*  TIASWCON: Set PA/TIA as unity gain buffer. */
+#define ENUM_AFE_LPTIASW0_BUFEN              0x000001A4            /*  TIASWCON: Set PA/TIA as unity gain buffer. Connect amp's output to CE0 & RC01. */
+#define ENUM_AFE_LPTIASW0_TWOLEAD            0x0000042C            /*  TIASWCON: Two lead sensor, set PA as unity gain buffer. */
+#define ENUM_AFE_LPTIASW0_BUFEN2             0x000004A4            /*  TIASWCON: Set PA/TIA as unity gain buffer. */
+#define ENUM_AFE_LPTIASW0_SESHORTRE          0x00000800            /*  TIASWCON: Close SW11 - Short SE0 to RE0. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_LPTIACON1                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_LPTIACON1_CHOPEN            16            /*  Chopping Enable */
+#define BITP_AFE_LPTIACON1_TIARF             13            /*  Set LPF Resistor */
+#define BITP_AFE_LPTIACON1_TIARL             10            /*  Set RLOAD */
+#define BITP_AFE_LPTIACON1_TIAGAIN            5            /*  Set RTIA Gain Resistor */
+#define BITP_AFE_LPTIACON1_IBOOST             3            /*  Current Boost Control */
+#define BITP_AFE_LPTIACON1_HALFPWR            2            /*  Half Power Mode Select */
+#define BITP_AFE_LPTIACON1_PAPDEN             1            /*  PA Power Down */
+#define BITP_AFE_LPTIACON1_TIAPDEN            0            /*  TIA Power Down */
+#define BITM_AFE_LPTIACON1_CHOPEN            (_ADI_MSK_3(0x00030000,0x00030000UL, uint32_t  ))    /*  Chopping Enable */
+#define BITM_AFE_LPTIACON1_TIARF             (_ADI_MSK_3(0x0000E000,0x0000E000UL, uint32_t  ))    /*  Set LPF Resistor */
+#define BITM_AFE_LPTIACON1_TIARL             (_ADI_MSK_3(0x00001C00,0x00001C00UL, uint32_t  ))    /*  Set RLOAD */
+#define BITM_AFE_LPTIACON1_TIAGAIN           (_ADI_MSK_3(0x000003E0,0x000003E0UL, uint32_t  ))    /*  Set RTIA Gain Resistor */
+#define BITM_AFE_LPTIACON1_IBOOST            (_ADI_MSK_3(0x00000018,0x00000018UL, uint32_t  ))    /*  Current Boost Control */
+#define BITM_AFE_LPTIACON1_HALFPWR           (_ADI_MSK_3(0x00000004,0x00000004UL, uint32_t  ))    /*  Half Power Mode Select */
+#define BITM_AFE_LPTIACON1_PAPDEN            (_ADI_MSK_3(0x00000002,0x00000002UL, uint32_t  ))    /*  PA Power Down */
+#define BITM_AFE_LPTIACON1_TIAPDEN           (_ADI_MSK_3(0x00000001,0x00000001UL, uint32_t  ))    /*  TIA Power Down */
+#define ENUM_AFE_LPTIACON1_DISCONRF          (_ADI_MSK_3(0x00000000,0x00000000UL, uint32_t  ))    /*  TIARF: Disconnect TIA output from LPF pin */
+#define ENUM_AFE_LPTIACON1_BYPRF             (_ADI_MSK_3(0x00002000,0x00002000UL, uint32_t  ))    /*  TIARF: Bypass resistor */
+#define ENUM_AFE_LPTIACON1_RF20K             (_ADI_MSK_3(0x00004000,0x00004000UL, uint32_t  ))    /*  TIARF: 20k Ohm */
+#define ENUM_AFE_LPTIACON1_RF100K            (_ADI_MSK_3(0x00006000,0x00006000UL, uint32_t  ))    /*  TIARF: 100k Ohm */
+#define ENUM_AFE_LPTIACON1_RF200K            (_ADI_MSK_3(0x00008000,0x00008000UL, uint32_t  ))    /*  TIARF: 200k Ohm */
+#define ENUM_AFE_LPTIACON1_RF400K            (_ADI_MSK_3(0x0000A000,0x0000A000UL, uint32_t  ))    /*  TIARF: 400k Ohm */
+#define ENUM_AFE_LPTIACON1_RF600K            (_ADI_MSK_3(0x0000C000,0x0000C000UL, uint32_t  ))    /*  TIARF: 600k Ohm */
+#define ENUM_AFE_LPTIACON1_RF1MOHM           (_ADI_MSK_3(0x0000E000,0x0000E000UL, uint32_t  ))    /*  TIARF: 1Meg Ohm */
+#define ENUM_AFE_LPTIACON1_RL0               (_ADI_MSK_3(0x00000000,0x00000000UL, uint32_t  ))    /*  TIARL: 0 ohm */
+#define ENUM_AFE_LPTIACON1_RL10              (_ADI_MSK_3(0x00000400,0x00000400UL, uint32_t  ))    /*  TIARL: 10 ohm */
+#define ENUM_AFE_LPTIACON1_RL30              (_ADI_MSK_3(0x00000800,0x00000800UL, uint32_t  ))    /*  TIARL: 30 ohm */
+#define ENUM_AFE_LPTIACON1_RL50              (_ADI_MSK_3(0x00000C00,0x00000C00UL, uint32_t  ))    /*  TIARL: 50 ohm */
+#define ENUM_AFE_LPTIACON1_RL100             (_ADI_MSK_3(0x00001000,0x00001000UL, uint32_t  ))    /*  TIARL: 100 ohm */
+#define ENUM_AFE_LPTIACON1_RL1P6K            (_ADI_MSK_3(0x00001400,0x00001400UL, uint32_t  ))    /*  TIARL: 1.6kohm */
+#define ENUM_AFE_LPTIACON1_RL3P1K            (_ADI_MSK_3(0x00001800,0x00001800UL, uint32_t  ))    /*  TIARL: 3.1kohm */
+#define ENUM_AFE_LPTIACON1_RL3P5K            (_ADI_MSK_3(0x00001C00,0x00001C00UL, uint32_t  ))    /*  TIARL: 3.6kohm */
+#define ENUM_AFE_LPTIACON1_DISCONTIA         (_ADI_MSK_3(0x00000000,0x00000000UL, uint32_t  ))    /*  TIAGAIN: Disconnect TIA Gain resistor */
+#define ENUM_AFE_LPTIACON1_TIAGAIN200        (_ADI_MSK_3(0x00000020,0x00000020UL, uint32_t  ))    /*  TIAGAIN: 200 Ohm */
+#define ENUM_AFE_LPTIACON1_TIAGAIN1K         (_ADI_MSK_3(0x00000040,0x00000040UL, uint32_t  ))    /*  TIAGAIN: 1k ohm */
+#define ENUM_AFE_LPTIACON1_TIAGAIN2K         (_ADI_MSK_3(0x00000060,0x00000060UL, uint32_t  ))    /*  TIAGAIN: 2k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN3K         (_ADI_MSK_3(0x00000080,0x00000080UL, uint32_t  ))    /*  TIAGAIN: 3k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN4K         (_ADI_MSK_3(0x000000A0,0x000000A0UL, uint32_t  ))    /*  TIAGAIN: 4k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN6K         (_ADI_MSK_3(0x000000C0,0x000000C0UL, uint32_t  ))    /*  TIAGAIN: 6k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN8K         (_ADI_MSK_3(0x000000E0,0x000000E0UL, uint32_t  ))    /*  TIAGAIN: 8k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN10K        (_ADI_MSK_3(0x00000100,0x00000100UL, uint32_t  ))    /*  TIAGAIN: 10k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN12K        (_ADI_MSK_3(0x00000120,0x00000120UL, uint32_t  ))    /*  TIAGAIN: 12k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN16K        (_ADI_MSK_3(0x00000140,0x00000140UL, uint32_t  ))    /*  TIAGAIN: 16k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN20K        (_ADI_MSK_3(0x00000160,0x00000160UL, uint32_t  ))    /*  TIAGAIN: 20k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN24K        (_ADI_MSK_3(0x00000180,0x00000180UL, uint32_t  ))    /*  TIAGAIN: 24k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN30K        (_ADI_MSK_3(0x000001A0,0x000001A0UL, uint32_t  ))    /*  TIAGAIN: 30k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN32K        (_ADI_MSK_3(0x000001C0,0x000001C0UL, uint32_t  ))    /*  TIAGAIN: 32k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN40K        (_ADI_MSK_3(0x000001E0,0x000001E0UL, uint32_t  ))    /*  TIAGAIN: 40k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN48K        (_ADI_MSK_3(0x00000200,0x00000200UL, uint32_t  ))    /*  TIAGAIN: 48k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN64K        (_ADI_MSK_3(0x00000220,0x00000220UL, uint32_t  ))    /*  TIAGAIN: 64k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN85K        (_ADI_MSK_3(0x00000240,0x00000240UL, uint32_t  ))    /*  TIAGAIN: 85k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN96K        (_ADI_MSK_3(0x00000260,0x00000260UL, uint32_t  ))    /*  TIAGAIN: 96k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN100K       (_ADI_MSK_3(0x00000280,0x00000280UL, uint32_t  ))    /*  TIAGAIN: 100k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN120K       (_ADI_MSK_3(0x000002A0,0x000002A0UL, uint32_t  ))    /*  TIAGAIN: 120k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN128K       (_ADI_MSK_3(0x000002C0,0x000002C0UL, uint32_t  ))    /*  TIAGAIN: 128k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN160K       (_ADI_MSK_3(0x000002E0,0x000002E0UL, uint32_t  ))    /*  TIAGAIN: 160k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN196K       (_ADI_MSK_3(0x00000300,0x00000300UL, uint32_t  ))    /*  TIAGAIN: 196k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN256K       (_ADI_MSK_3(0x00000320,0x00000320UL, uint32_t  ))    /*  TIAGAIN: 256k */
+#define ENUM_AFE_LPTIACON1_TIAGAIN512K       (_ADI_MSK_3(0x00000340,0x00000340UL, uint32_t  ))    /*  TIAGAIN: 512k */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_LPTIACON0                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_LPTIACON0_CHOPEN            16            /*  Chopping Enable */
+#define BITP_AFE_LPTIACON0_TIARF             13            /*  Set LPF Resistor */
+#define BITP_AFE_LPTIACON0_TIARL             10            /*  Set RLOAD */
+#define BITP_AFE_LPTIACON0_TIAGAIN            5            /*  Set RTIA */
+#define BITP_AFE_LPTIACON0_IBOOST             3            /*  Current Boost Control */
+#define BITP_AFE_LPTIACON0_HALFPWR            2            /*  Half Power Mode Select */
+#define BITP_AFE_LPTIACON0_PAPDEN             1            /*  PA Power Down */
+#define BITP_AFE_LPTIACON0_TIAPDEN            0            /*  TIA Power Down */
+#define BITM_AFE_LPTIACON0_CHOPEN            0x00030000    /*  Chopping Enable */
+#define BITM_AFE_LPTIACON0_TIARF             0x0000E000    /*  Set LPF Resistor */
+#define BITM_AFE_LPTIACON0_TIARL             0x00001C00    /*  Set RLOAD */
+#define BITM_AFE_LPTIACON0_TIAGAIN           0x000003E0    /*  Set RTIA */
+#define BITM_AFE_LPTIACON0_IBOOST            0x00000018    /*  Current Boost Control */
+#define BITM_AFE_LPTIACON0_HALFPWR           0x00000004    /*  Half Power Mode Select */
+#define BITM_AFE_LPTIACON0_PAPDEN            0x00000002    /*  PA Power Down */
+#define BITM_AFE_LPTIACON0_TIAPDEN           0x00000001    /*  TIA Power Down */
+#define ENUM_AFE_LPTIACON0_DISCONRF          0x00000000            /*  TIARF: Disconnect TIA output from LPF pin */
+#define ENUM_AFE_LPTIACON0_BYPRF             0x00002000            /*  TIARF: Bypass resistor */
+#define ENUM_AFE_LPTIACON0_RF20K             0x00004000            /*  TIARF: 20k Ohm */
+#define ENUM_AFE_LPTIACON0_RF100K            0x00006000            /*  TIARF: 100k Ohm */
+#define ENUM_AFE_LPTIACON0_RF200K            0x00008000            /*  TIARF: 200k Ohm */
+#define ENUM_AFE_LPTIACON0_RF400K            0x0000A000            /*  TIARF: 400k Ohm */
+#define ENUM_AFE_LPTIACON0_RF600K            0x0000C000            /*  TIARF: 600k Ohm */
+#define ENUM_AFE_LPTIACON0_RF1MOHM           0x0000E000            /*  TIARF: 1Meg Ohm */
+#define ENUM_AFE_LPTIACON0_RL0               0x00000000            /*  TIARL: 0 ohm */
+#define ENUM_AFE_LPTIACON0_RL10              0x00000400            /*  TIARL: 10 ohm */
+#define ENUM_AFE_LPTIACON0_RL30              0x00000800            /*  TIARL: 30 ohm */
+#define ENUM_AFE_LPTIACON0_RL50              0x00000C00            /*  TIARL: 50 ohm */
+#define ENUM_AFE_LPTIACON0_RL100             0x00001000            /*  TIARL: 100 ohm */
+#define ENUM_AFE_LPTIACON0_RL1P6K            0x00001400            /*  TIARL: 1.6kohm */
+#define ENUM_AFE_LPTIACON0_RL3P1K            0x00001800            /*  TIARL: 3.1kohm */
+#define ENUM_AFE_LPTIACON0_RL3P5K            0x00001C00            /*  TIARL: 3.6kohm */
+#define ENUM_AFE_LPTIACON0_DISCONTIA         0x00000000            /*  TIAGAIN: Disconnect TIA Gain resistor */
+#define ENUM_AFE_LPTIACON0_TIAGAIN200        0x00000020            /*  TIAGAIN: 200 Ohm */
+#define ENUM_AFE_LPTIACON0_TIAGAIN1K         0x00000040            /*  TIAGAIN: 1k ohm */
+#define ENUM_AFE_LPTIACON0_TIAGAIN2K         0x00000060            /*  TIAGAIN: 2k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN3K         0x00000080            /*  TIAGAIN: 3k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN4K         0x000000A0            /*  TIAGAIN: 4k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN6K         0x000000C0            /*  TIAGAIN: 6k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN8K         0x000000E0            /*  TIAGAIN: 8k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN10K        0x00000100            /*  TIAGAIN: 10k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN12K        0x00000120            /*  TIAGAIN: 12k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN16K        0x00000140            /*  TIAGAIN: 16k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN20K        0x00000160            /*  TIAGAIN: 20k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN24K        0x00000180            /*  TIAGAIN: 24k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN30K        0x000001A0            /*  TIAGAIN: 30k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN32K        0x000001C0            /*  TIAGAIN: 32k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN40K        0x000001E0            /*  TIAGAIN: 40k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN48K        0x00000200            /*  TIAGAIN: 48k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN64K        0x00000220            /*  TIAGAIN: 64k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN85K        0x00000240            /*  TIAGAIN: 85k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN96K        0x00000260            /*  TIAGAIN: 96k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN100K       0x00000280            /*  TIAGAIN: 100k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN120K       0x000002A0            /*  TIAGAIN: 120k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN128K       0x000002C0            /*  TIAGAIN: 128k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN160K       0x000002E0            /*  TIAGAIN: 160k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN196K       0x00000300            /*  TIAGAIN: 196k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN256K       0x00000320            /*  TIAGAIN: 256k */
+#define ENUM_AFE_LPTIACON0_TIAGAIN512K       0x00000340            /*  TIAGAIN: 512k */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_HSRTIACON                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_HSRTIACON_CTIACON            5            /*  Configure Capacitor in Parallel with RTIA */
+#define BITP_AFE_HSRTIACON_TIASW6CON          4            /*  SW6 Control */
+#define BITP_AFE_HSRTIACON_RTIACON            0            /*  Configure General RTIA Value */
+#define BITM_AFE_HSRTIACON_CTIACON           0x00001FE0    /*  Configure Capacitor in Parallel with RTIA */
+#define BITM_AFE_HSRTIACON_TIASW6CON         0x00000010    /*  SW6 Control */
+#define BITM_AFE_HSRTIACON_RTIACON           0x0000000F    /*  Configure General RTIA Value */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_DE1RESCON                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_DE1RESCON_DE1RCON            0            /*  DE1 RLOAD RTIA Setting */
+#define BITM_AFE_DE1RESCON_DE1RCON           (_ADI_MSK_3(0x000000FF,0x000000FFUL, uint32_t  ))    /*  DE1 RLOAD RTIA Setting */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_DE0RESCON                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_DE0RESCON_DE0RCON            0            /*  DE0 RLOAD RTIA Setting */
+#define BITM_AFE_DE0RESCON_DE0RCON           0x000000FF    /*  DE0 RLOAD RTIA Setting */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_HSTIACON                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_HSTIACON_VBIASSEL            0            /*  Select HSTIA Positive Input */
+#define BITM_AFE_HSTIACON_VBIASSEL           0x00000003    /*  Select HSTIA Positive Input */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_DACDCBUFCON                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_DACDCBUFCON_CHANSEL          1            /*  DAC DC Channel Selection */
+#define BITP_AFE_DACDCBUFCON_RESERVED_0       0            /*  Reserved */
+#define BITM_AFE_DACDCBUFCON_CHANSEL         (_ADI_MSK_3(0x00000002,0x00000002UL, uint32_t  ))    /*  DAC DC Channel Selection */
+#define BITM_AFE_DACDCBUFCON_RESERVED_0      (_ADI_MSK_3(0x00000001,0x00000001UL, uint32_t  ))    /*  Reserved */
+#define ENUM_AFE_DACDCBUFCON_CHAN0           (_ADI_MSK_3(0x00000000,0x00000000UL, uint32_t  ))    /*  CHANSEL: ULPDAC0 Sets DC level */
+#define ENUM_AFE_DACDCBUFCON_CHAN1           (_ADI_MSK_3(0x00000002,0x00000002UL, uint32_t  ))    /*  CHANSEL: ULPDAC1 Sets DC level */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_LPMODEKEY                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_LPMODEKEY_KEY               0            /*  LP Key */
+#define BITM_AFE_LPMODEKEY_KEY              0x000FFFFF    /*  LP Key */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_LPMODECLKSEL                    Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_LPMODECLKSEL_LFSYSCLKEN     0            /*  Enable Switching System Clock to 32KHz by Sequencer */
+#define BITM_AFE_LPMODECLKSEL_LFSYSCLKEN    0x00000001    /*  Enable Switching System Clock to 32KHz by Sequencer */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_LPMODECON                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_LPMODECON_ALDOEN            8            /*  Set High to Power Down of Analog LDO */
+#define BITP_AFE_LPMODECON_V1P1HPADCEN       7            /*  Set High to Enable 1.1V HP CM Buffer */
+#define BITP_AFE_LPMODECON_V1P8HPADCEN       6            /*  Set High to Enable HP 1.8V Reference Buffer */
+#define BITP_AFE_LPMODECON_PTATEN            5            /*  Set to High to Generate Ptat Current Bias */
+#define BITP_AFE_LPMODECON_ZTATEN            4            /*  Set High to Generate Ztat Current Bias */
+#define BITP_AFE_LPMODECON_REPEATADCCNVEN_P  3            /*  Set High to Enable Repeat ADC Conversion */
+#define BITP_AFE_LPMODECON_ADCCONVEN         2            /*  Set High to Enable ADC Conversion */
+#define BITP_AFE_LPMODECON_HPREFDIS          1            /*  Set High to Power Down HP Reference */
+#define BITP_AFE_LPMODECON_HFOSCPD           0            /*  Set High to Power Down HP Power Oscillator */
+#define BITM_AFE_LPMODECON_ALDOEN           0x00000100    /*  Set High to Power Down of Analog LDO */
+#define BITM_AFE_LPMODECON_V1P1HPADCEN      0x00000080    /*  Set High to Enable 1.1V HP CM Buffer */
+#define BITM_AFE_LPMODECON_V1P8HPADCEN      0x00000040    /*  Set High to Enable HP 1.8V Reference Buffer */
+#define BITM_AFE_LPMODECON_PTATEN           0x00000020    /*  Set to High to Generate Ptat Current Bias */
+#define BITM_AFE_LPMODECON_ZTATEN           0x00000010    /*  Set High to Generate Ztat Current Bias */
+#define BITM_AFE_LPMODECON_REPEATADCCNVEN_P 0x00000008    /*  Set High to Enable Repeat ADC Conversion */
+#define BITM_AFE_LPMODECON_ADCCONVEN        0x00000004    /*  Set High to Enable ADC Conversion */
+#define BITM_AFE_LPMODECON_HPREFDIS         0x00000002    /*  Set High to Power Down HP Reference */
+#define BITM_AFE_LPMODECON_HFOSCPD          0x00000001    /*  Set High to Power Down HP Power Oscillator */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_SEQSLPLOCK                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_SEQSLPLOCK_SEQ_SLP_PW        0            /*  Password for SLPBYSEQ Register */
+#define BITM_AFE_SEQSLPLOCK_SEQ_SLP_PW       0x000FFFFF    /*  Password for SLPBYSEQ Register */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_SEQTRGSLP                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_SEQTRGSLP_TRGSLP             0            /*  Trigger Sleep by Sequencer */
+#define BITM_AFE_SEQTRGSLP_TRGSLP            0x00000001    /*  Trigger Sleep by Sequencer */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_LPDACDAT0                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_LPDACDAT0_DACIN6            12            /*  6BITVAL, 1LSB=34.375mV */
+#define BITP_AFE_LPDACDAT0_DACIN12            0            /*  12BITVAL, 1LSB=537uV */
+#define BITM_AFE_LPDACDAT0_DACIN6            0x0003F000    /*  6BITVAL, 1LSB=34.375mV */
+#define BITM_AFE_LPDACDAT0_DACIN12           0x00000FFF    /*  12BITVAL, 1LSB=537uV */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_LPDACSW0                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_LPDACSW0_LPMODEDIS           5            /*  Switch Control */
+#define BITP_AFE_LPDACSW0_LPDACSW             0            /*  LPDAC0 Switches Matrix */
+#define BITM_AFE_LPDACSW0_LPMODEDIS          0x00000020    /*  Switch Control */
+#define BITM_AFE_LPDACSW0_LPDACSW            0x0000001F    /*  LPDAC0 Switches Matrix */
+#define ENUM_AFE_LPDACSW0_DACCONBIT5         0x00000000            /*  LPMODEDIS: REG_AFE_LPDACDAT0 Switch controlled by REG_AFE_LPDACDAT0CON0 bit 5 */
+#define ENUM_AFE_LPDACSW0_OVRRIDE            0x00000020            /*  LPMODEDIS: REG_AFE_LPDACDAT0 Switches override */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_LPDACCON0                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_LPDACCON0_WAVETYPE           6            /*  LPDAC Data Source */
+#define BITP_AFE_LPDACCON0_DACMDE             5            /*  LPDAC0 Switch Settings */
+#define BITP_AFE_LPDACCON0_VZEROMUX           4            /*  VZERO MUX Select */
+#define BITP_AFE_LPDACCON0_VBIASMUX           3            /*  VBIAS MUX Select */
+#define BITP_AFE_LPDACCON0_REFSEL             2            /*  Reference Select Bit */
+#define BITP_AFE_LPDACCON0_PWDEN              1            /*  LPDAC0 Power Down */
+#define BITP_AFE_LPDACCON0_RSTEN              0            /*  Enable Writes to REG_AFE_LPDACDAT00 */
+#define BITM_AFE_LPDACCON0_WAVETYPE          0x00000040    /*  LPDAC Data Source */
+#define BITM_AFE_LPDACCON0_DACMDE            0x00000020    /*  LPDAC0 Switch Settings */
+#define BITM_AFE_LPDACCON0_VZEROMUX          0x00000010    /*  VZERO MUX Select */
+#define BITM_AFE_LPDACCON0_VBIASMUX          0x00000008    /*  VBIAS MUX Select */
+#define BITM_AFE_LPDACCON0_REFSEL            0x00000004    /*  Reference Select Bit */
+#define BITM_AFE_LPDACCON0_PWDEN             0x00000002    /*  LPDAC0 Power Down */
+#define BITM_AFE_LPDACCON0_RSTEN             0x00000001    /*  Enable Writes to REG_AFE_LPDACDAT00 */
+#define ENUM_AFE_LPDACCON0_MMR               0x00000000            /*  WAVETYPE: Direct from REG_AFE_LPDACDAT0DAT0 */
+#define ENUM_AFE_LPDACCON0_WAVEGEN           0x00000040            /*  WAVETYPE: Waveform generator */
+#define ENUM_AFE_LPDACCON0_NORM              0x00000000            /*  DACMDE: REG_AFE_LPDACDAT00 switches set for normal mode */
+#define ENUM_AFE_LPDACCON0_DIAG              0x00000020            /*  DACMDE: REG_AFE_LPDACDAT00 switches set for Diagnostic mode */
+#define ENUM_AFE_LPDACCON0_BITS6             0x00000000            /*  VZEROMUX: VZERO 6BIT */
+#define ENUM_AFE_LPDACCON0_BITS12            0x00000010            /*  VZEROMUX: VZERO 12BIT */
+#define ENUM_AFE_LPDACCON0_12BIT             0x00000000            /*  VBIASMUX: Output 12Bit */
+#define ENUM_AFE_LPDACCON0_EN                0x00000008            /*  VBIASMUX: output 6Bit */
+#define ENUM_AFE_LPDACCON0_ULPREF            0x00000000            /*  REFSEL: ULP2P5V Ref */
+#define ENUM_AFE_LPDACCON0_AVDD              0x00000004            /*  REFSEL: AVDD Reference */
+#define ENUM_AFE_LPDACCON0_PWREN             0x00000000            /*  PWDEN: REG_AFE_LPDACDAT00 Powered On */
+#define ENUM_AFE_LPDACCON0_PWRDIS            0x00000002            /*  PWDEN: REG_AFE_LPDACDAT00 Powered Off */
+#define ENUM_AFE_LPDACCON0_WRITEDIS          0x00000000            /*  RSTEN: Disable REG_AFE_LPDACDAT00 Writes */
+#define ENUM_AFE_LPDACCON0_WRITEEN           0x00000001            /*  RSTEN: Enable REG_AFE_LPDACDAT00 Writes */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_LPDACDAT1                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_LPDACDAT1_DACIN6            12            /*  6BITVAL, 1LSB=34.375mV */
+#define BITP_AFE_LPDACDAT1_DACIN12            0            /*  12BITVAL, 1LSB=537uV */
+#define BITM_AFE_LPDACDAT1_DACIN6            (_ADI_MSK_3(0x0003F000,0x0003F000UL, uint32_t  ))    /*  6BITVAL, 1LSB=34.375mV */
+#define BITM_AFE_LPDACDAT1_DACIN12           (_ADI_MSK_3(0x00000FFF,0x00000FFFUL, uint32_t  ))    /*  12BITVAL, 1LSB=537uV */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_LPDACSW1                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_LPDACSW1_LPMODEDIS           5            /*  Switch Control */
+#define BITP_AFE_LPDACSW1_LPDACSW             0            /*  ULPDAC0 Switches Matrix */
+#define BITM_AFE_LPDACSW1_LPMODEDIS          (_ADI_MSK_3(0x00000020,0x00000020UL, uint32_t  ))    /*  Switch Control */
+#define BITM_AFE_LPDACSW1_LPDACSW            (_ADI_MSK_3(0x0000001F,0x0000001FUL, uint32_t  ))    /*  ULPDAC0 Switches Matrix */
+#define ENUM_AFE_LPDACSW1_DACCONBIT5         (_ADI_MSK_3(0x00000000,0x00000000UL, uint32_t  ))    /*  LPMODEDIS: ULPDAC Switch controlled by ULPDACCON1 bit 5 */
+#define ENUM_AFE_LPDACSW1_OVRRIDE            (_ADI_MSK_3(0x00000020,0x00000020UL, uint32_t  ))    /*  LPMODEDIS: ULPDAC Switches override */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_LPDACCON1                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_LPDACCON1_WAVETYPE           6            /*  DAC Input Source */
+#define BITP_AFE_LPDACCON1_DACMDE             5            /*  LPDAC1 Switch Settings */
+#define BITP_AFE_LPDACCON1_VZEROMUX           4            /*  VZEROOUT */
+#define BITP_AFE_LPDACCON1_VBIASMUX           3            /*  BITSEL */
+#define BITP_AFE_LPDACCON1_REFSEL             2            /*  REFSEL */
+#define BITP_AFE_LPDACCON1_PWDEN              1            /*  ULPDAC0 Power */
+#define BITP_AFE_LPDACCON1_RSTEN              0            /*  Enable Writes to ULPDAC1 */
+#define BITM_AFE_LPDACCON1_WAVETYPE          (_ADI_MSK_3(0x00000040,0x00000040UL, uint32_t  ))    /*  DAC Input Source */
+#define BITM_AFE_LPDACCON1_DACMDE            (_ADI_MSK_3(0x00000020,0x00000020UL, uint32_t  ))    /*  LPDAC1 Switch Settings */
+#define BITM_AFE_LPDACCON1_VZEROMUX          (_ADI_MSK_3(0x00000010,0x00000010UL, uint32_t  ))    /*  VZEROOUT */
+#define BITM_AFE_LPDACCON1_VBIASMUX          (_ADI_MSK_3(0x00000008,0x00000008UL, uint32_t  ))    /*  BITSEL */
+#define BITM_AFE_LPDACCON1_REFSEL            (_ADI_MSK_3(0x00000004,0x00000004UL, uint32_t  ))    /*  REFSEL */
+#define BITM_AFE_LPDACCON1_PWDEN             (_ADI_MSK_3(0x00000002,0x00000002UL, uint32_t  ))    /*  ULPDAC0 Power */
+#define BITM_AFE_LPDACCON1_RSTEN             (_ADI_MSK_3(0x00000001,0x00000001UL, uint32_t  ))    /*  Enable Writes to ULPDAC1 */
+#define ENUM_AFE_LPDACCON1_NORM              (_ADI_MSK_3(0x00000000,0x00000000UL, uint32_t  ))    /*  DACMDE: ULPDAC1 switches set for normal mode */
+#define ENUM_AFE_LPDACCON1_DIAG              (_ADI_MSK_3(0x00000020,0x00000020UL, uint32_t  ))    /*  DACMDE: ULPDAC1 switches set for Diagnostic mode */
+#define ENUM_AFE_LPDACCON1_BITS6             (_ADI_MSK_3(0x00000000,0x00000000UL, uint32_t  ))    /*  VZEROMUX: VZERO 6BIT */
+#define ENUM_AFE_LPDACCON1_BITS12            (_ADI_MSK_3(0x00000010,0x00000010UL, uint32_t  ))    /*  VZEROMUX: VZERO 12BIT */
+#define ENUM_AFE_LPDACCON1_DIS               (_ADI_MSK_3(0x00000000,0x00000000UL, uint32_t  ))    /*  VBIASMUX: 12BIT Output */
+#define ENUM_AFE_LPDACCON1_EN                (_ADI_MSK_3(0x00000008,0x00000008UL, uint32_t  ))    /*  VBIASMUX: 6BIT Output */
+#define ENUM_AFE_LPDACCON1_ULPREF            (_ADI_MSK_3(0x00000000,0x00000000UL, uint32_t  ))
+#define ENUM_AFE_LPDACCON1_AVDD              (_ADI_MSK_3(0x00000004,0x00000004UL, uint32_t  ))
+#define ENUM_AFE_LPDACCON1_PWREN             (_ADI_MSK_3(0x00000000,0x00000000UL, uint32_t  ))    /*  PWDEN: ULPDAC1 Powered On */
+#define ENUM_AFE_LPDACCON1_PWRDIS            (_ADI_MSK_3(0x00000002,0x00000002UL, uint32_t  ))    /*  PWDEN: ULPDAC1 Powered Off */
+#define ENUM_AFE_LPDACCON1_WRITEDIS          (_ADI_MSK_3(0x00000000,0x00000000UL, uint32_t  ))    /*  RSTEN: Disable ULPDAC1 Writes */
+#define ENUM_AFE_LPDACCON1_WRITEEN           (_ADI_MSK_3(0x00000001,0x00000001UL, uint32_t  ))    /*  RSTEN: Enable ULPDAC1 Writes */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_DSWFULLCON                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_DSWFULLCON_D8                7            /*  Control of D8 Switch. */
+#define BITP_AFE_DSWFULLCON_D7                6            /*  Control of D7 Switch. */
+#define BITP_AFE_DSWFULLCON_D6                5            /*  Control of D6 Switch. */
+#define BITP_AFE_DSWFULLCON_D5                4            /*  Control of D5 Switch. */
+#define BITP_AFE_DSWFULLCON_D4                3            /*  Control of D4 Switch. */
+#define BITP_AFE_DSWFULLCON_D3                2            /*  Control of D3 Switch. */
+#define BITP_AFE_DSWFULLCON_D2                1            /*  Control of D2 Switch. */
+#define BITP_AFE_DSWFULLCON_DR0               0            /*  Control of Dr0 Switch. */
+#define BITM_AFE_DSWFULLCON_D8               0x00000080    /*  Control of D8 Switch. */
+#define BITM_AFE_DSWFULLCON_D7               0x00000040    /*  Control of D7 Switch. */
+#define BITM_AFE_DSWFULLCON_D6               0x00000020    /*  Control of D6 Switch. */
+#define BITM_AFE_DSWFULLCON_D5               0x00000010    /*  Control of D5 Switch. */
+#define BITM_AFE_DSWFULLCON_D4               0x00000008    /*  Control of D4 Switch. */
+#define BITM_AFE_DSWFULLCON_D3               0x00000004    /*  Control of D3 Switch. */
+#define BITM_AFE_DSWFULLCON_D2               0x00000002    /*  Control of D2 Switch. */
+#define BITM_AFE_DSWFULLCON_DR0              0x00000001    /*  Control of Dr0 Switch. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_NSWFULLCON                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_NSWFULLCON_NL2              11            /*  Control of NL2 Switch. */
+#define BITP_AFE_NSWFULLCON_NL               10            /*  Control of NL Switch. */
+#define BITP_AFE_NSWFULLCON_NR1               9            /*  Control of Nr1 Switch. Set Will Close Nr1, Unset Open */
+#define BITP_AFE_NSWFULLCON_N9                8            /*  Control of N9 Switch. Set Will Close N9, Unset Open */
+#define BITP_AFE_NSWFULLCON_N8                7            /*  Control of N8 Switch. Set Will Close N8, Unset Open */
+#define BITP_AFE_NSWFULLCON_N7                6            /*  Control of N7 Switch. Set Will Close N7, Unset Open */
+#define BITP_AFE_NSWFULLCON_N6                5            /*  Control of N6 Switch. Set Will Close N6, Unset Open */
+#define BITP_AFE_NSWFULLCON_N5                4            /*  Control of N5 Switch. Set Will Close N5, Unset Open */
+#define BITP_AFE_NSWFULLCON_N4                3            /*  Control of N4 Switch. Set Will Close N4, Unset Open */
+#define BITP_AFE_NSWFULLCON_N3                2            /*  Control of N3 Switch. Set Will Close N3, Unset Open */
+#define BITP_AFE_NSWFULLCON_N2                1            /*  Control of N2 Switch. Set Will Close N2, Unset Open */
+#define BITP_AFE_NSWFULLCON_N1                0            /*  Control of N1 Switch. Set Will Close N1, Unset Open */
+#define BITM_AFE_NSWFULLCON_NL2              0x00000800    /*  Control of NL2 Switch. */
+#define BITM_AFE_NSWFULLCON_NL               0x00000400    /*  Control of NL Switch. */
+#define BITM_AFE_NSWFULLCON_NR1              0x00000200    /*  Control of Nr1 Switch. Set Will Close Nr1, Unset Open */
+#define BITM_AFE_NSWFULLCON_N9               0x00000100    /*  Control of N9 Switch. Set Will Close N9, Unset Open */
+#define BITM_AFE_NSWFULLCON_N8               0x00000080    /*  Control of N8 Switch. Set Will Close N8, Unset Open */
+#define BITM_AFE_NSWFULLCON_N7               0x00000040    /*  Control of N7 Switch. Set Will Close N7, Unset Open */
+#define BITM_AFE_NSWFULLCON_N6               0x00000020    /*  Control of N6 Switch. Set Will Close N6, Unset Open */
+#define BITM_AFE_NSWFULLCON_N5               0x00000010    /*  Control of N5 Switch. Set Will Close N5, Unset Open */
+#define BITM_AFE_NSWFULLCON_N4               0x00000008    /*  Control of N4 Switch. Set Will Close N4, Unset Open */
+#define BITM_AFE_NSWFULLCON_N3               0x00000004    /*  Control of N3 Switch. Set Will Close N3, Unset Open */
+#define BITM_AFE_NSWFULLCON_N2               0x00000002    /*  Control of N2 Switch. Set Will Close N2, Unset Open */
+#define BITM_AFE_NSWFULLCON_N1               0x00000001    /*  Control of N1 Switch. Set Will Close N1, Unset Open */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_PSWFULLCON                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_PSWFULLCON_PL2              14            /*  PL2 Switch Control */
+#define BITP_AFE_PSWFULLCON_PL               13            /*  PL Switch Control */
+#define BITP_AFE_PSWFULLCON_P12              11            /*  Control of P12 Switch. Set Will Close P12, Unset Open */
+#define BITP_AFE_PSWFULLCON_P11              10            /*  Control of P11 Switch. Set Will Close P11, Unset Open */
+#define BITP_AFE_PSWFULLCON_P10               9            /*  P10 Switch Control */
+#define BITP_AFE_PSWFULLCON_P9                8            /*  Control of P9 Switch. Set Will Close P9, Unset Open */
+#define BITP_AFE_PSWFULLCON_P8                7            /*  Control of P8 Switch. Set Will Close P8, Unset Open */
+#define BITP_AFE_PSWFULLCON_P7                6            /*  Control of P7 Switch. Set Will Close P7, Unset Open */
+#define BITP_AFE_PSWFULLCON_P6                5            /*  Control of P6 Switch. Set Will Close P6, Unset Open */
+#define BITP_AFE_PSWFULLCON_P5                4            /*  Control of P5 Switch. Set Will Close P5, Unset Open */
+#define BITP_AFE_PSWFULLCON_P4                3            /*  Control of P4 Switch. Set Will Close P4, Unset Open */
+#define BITP_AFE_PSWFULLCON_P3                2            /*  Control of P3 Switch. Set Will Close P3, Unset Open */
+#define BITP_AFE_PSWFULLCON_P2                1            /*  Control of P2 Switch. Set Will Close P2, Unset Open */
+#define BITP_AFE_PSWFULLCON_PR0               0            /*  PR0 Switch Control */
+#define BITM_AFE_PSWFULLCON_PL2              0x00004000    /*  PL2 Switch Control */
+#define BITM_AFE_PSWFULLCON_PL               0x00002000    /*  PL Switch Control */
+#define BITM_AFE_PSWFULLCON_P12              0x00000800    /*  Control of P12 Switch. Set Will Close P12, Unset Open */
+#define BITM_AFE_PSWFULLCON_P11              0x00000400    /*  Control of P11 Switch. Set Will Close P11, Unset Open */
+#define BITM_AFE_PSWFULLCON_P10              0x00000200    /*  P10 Switch Control */
+#define BITM_AFE_PSWFULLCON_P9               0x00000100    /*  Control of P9 Switch. Set Will Close P9, Unset Open */
+#define BITM_AFE_PSWFULLCON_P8               0x00000080    /*  Control of P8 Switch. Set Will Close P8, Unset Open */
+#define BITM_AFE_PSWFULLCON_P7               0x00000040    /*  Control of P7 Switch. Set Will Close P7, Unset Open */
+#define BITM_AFE_PSWFULLCON_P6               0x00000020    /*  Control of P6 Switch. Set Will Close P6, Unset Open */
+#define BITM_AFE_PSWFULLCON_P5               0x00000010    /*  Control of P5 Switch. Set Will Close P5, Unset Open */
+#define BITM_AFE_PSWFULLCON_P4               0x00000008    /*  Control of P4 Switch. Set Will Close P4, Unset Open */
+#define BITM_AFE_PSWFULLCON_P3               0x00000004    /*  Control of P3 Switch. Set Will Close P3, Unset Open */
+#define BITM_AFE_PSWFULLCON_P2               0x00000002    /*  Control of P2 Switch. Set Will Close P2, Unset Open */
+#define BITM_AFE_PSWFULLCON_PR0              0x00000001    /*  PR0 Switch Control */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_TSWFULLCON                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_TSWFULLCON_TR1              11            /*  Control of Tr1 Switch. Set Will Close Tr1, Unset Open */
+#define BITP_AFE_TSWFULLCON_T11              10            /*  Control of T11 Switch. Set Will Close T11, Unset Open */
+#define BITP_AFE_TSWFULLCON_T10               9            /*  Control of T10 Switch. Set Will Close T10, Unset Open */
+#define BITP_AFE_TSWFULLCON_T9                8            /*  Control of T9 Switch. Set Will Close T9, Unset Open */
+#define BITP_AFE_TSWFULLCON_T7                6            /*  Control of T7 Switch. Set Will Close T7, Unset Open */
+#define BITP_AFE_TSWFULLCON_T5                4            /*  Control of T5 Switch. Set Will Close T5, Unset Open */
+#define BITP_AFE_TSWFULLCON_T4                3            /*  Control of T4 Switch. Set Will Close T4, Unset Open */
+#define BITP_AFE_TSWFULLCON_T3                2            /*  Control of T3 Switch. Set Will Close T3, Unset Open */
+#define BITP_AFE_TSWFULLCON_T2                1            /*  Control of T2 Switch. Set Will Close T2, Unset Open */
+#define BITP_AFE_TSWFULLCON_T1                0            /*  Control of T1 Switch. Set Will Close T1, Unset Open */
+#define BITM_AFE_TSWFULLCON_TR1              0x00000800    /*  Control of Tr1 Switch. Set Will Close Tr1, Unset Open */
+#define BITM_AFE_TSWFULLCON_T11              0x00000400    /*  Control of T11 Switch. Set Will Close T11, Unset Open */
+#define BITM_AFE_TSWFULLCON_T10              0x00000200    /*  Control of T10 Switch. Set Will Close T10, Unset Open */
+#define BITM_AFE_TSWFULLCON_T9               0x00000100    /*  Control of T9 Switch. Set Will Close T9, Unset Open */
+#define BITM_AFE_TSWFULLCON_T7               0x00000040    /*  Control of T7 Switch. Set Will Close T7, Unset Open */
+#define BITM_AFE_TSWFULLCON_T5               0x00000010    /*  Control of T5 Switch. Set Will Close T5, Unset Open */
+#define BITM_AFE_TSWFULLCON_T4               0x00000008    /*  Control of T4 Switch. Set Will Close T4, Unset Open */
+#define BITM_AFE_TSWFULLCON_T3               0x00000004    /*  Control of T3 Switch. Set Will Close T3, Unset Open */
+#define BITM_AFE_TSWFULLCON_T2               0x00000002    /*  Control of T2 Switch. Set Will Close T2, Unset Open */
+#define BITM_AFE_TSWFULLCON_T1               0x00000001    /*  Control of T1 Switch. Set Will Close T1, Unset Open */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_TEMPSENS                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_TEMPSENS_CHOPFRESEL          2            /*  Chop Mode Frequency Setting */
+#define BITP_AFE_TEMPSENS_CHOPCON             1            /*  Temp Sensor Chop Mode */
+#define BITP_AFE_TEMPSENS_ENABLE              0            /*  Unused */
+#define BITM_AFE_TEMPSENS_CHOPFRESEL         0x0000000C    /*  Chop Mode Frequency Setting */
+#define BITM_AFE_TEMPSENS_CHOPCON            0x00000002    /*  Temp Sensor Chop Mode */
+#define BITM_AFE_TEMPSENS_ENABLE             0x00000001    /*  Unused */
+#define ENUM_AFE_TEMPSENS_DIS                0x00000000            /*  CHOPCON: Disable chop */
+#define ENUM_AFE_TEMPSENS_EN                 0x00000002            /*  CHOPCON: Enable chop */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_BUFSENCON                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_BUFSENCON_V1P8THERMSTEN      8            /*  Buffered Reference Output */
+#define BITP_AFE_BUFSENCON_V1P1LPADCCHGDIS    6            /*  Controls Decoupling Cap Discharge Switch */
+#define BITP_AFE_BUFSENCON_V1P1LPADCEN        5            /*  ADC 1.1V LP Buffer */
+#define BITP_AFE_BUFSENCON_V1P1HPADCEN        4            /*  Enable 1.1V HP CM Buffer */
+#define BITP_AFE_BUFSENCON_V1P8HPADCCHGDIS    3            /*  Controls Decoupling Cap Discharge Switch */
+#define BITP_AFE_BUFSENCON_V1P8LPADCEN        2            /*  ADC 1.8V LP Reference Buffer */
+#define BITP_AFE_BUFSENCON_V1P8HPADCILIMITEN  1            /*  HP ADC Input Current Limit */
+#define BITP_AFE_BUFSENCON_V1P8HPADCEN        0            /*  HP 1.8V Reference Buffer */
+#define BITM_AFE_BUFSENCON_V1P8THERMSTEN     0x00000100    /*  Buffered Reference Output */
+#define BITM_AFE_BUFSENCON_V1P1LPADCCHGDIS   0x00000040    /*  Controls Decoupling Cap Discharge Switch */
+#define BITM_AFE_BUFSENCON_V1P1LPADCEN       0x00000020    /*  ADC 1.1V LP Buffer */
+#define BITM_AFE_BUFSENCON_V1P1HPADCEN       0x00000010    /*  Enable 1.1V HP CM Buffer */
+#define BITM_AFE_BUFSENCON_V1P8HPADCCHGDIS   0x00000008    /*  Controls Decoupling Cap Discharge Switch */
+#define BITM_AFE_BUFSENCON_V1P8LPADCEN       0x00000004    /*  ADC 1.8V LP Reference Buffer */
+#define BITM_AFE_BUFSENCON_V1P8HPADCILIMITEN 0x00000002    /*  HP ADC Input Current Limit */
+#define BITM_AFE_BUFSENCON_V1P8HPADCEN       0x00000001    /*  HP 1.8V Reference Buffer */
+#define ENUM_AFE_BUFSENCON_DIS               0x00000000            /*  V1P8THERMSTEN: Disable 1.8V Buffered Reference output */
+#define ENUM_AFE_BUFSENCON_EN                0x00000100            /*  V1P8THERMSTEN: Enable 1.8V Buffered Reference output */
+#define ENUM_AFE_BUFSENCON_ENCHRG            0x00000000            /*  V1P1LPADCCHGDIS: Open switch */
+#define ENUM_AFE_BUFSENCON_DISCHRG           0x00000040            /*  V1P1LPADCCHGDIS: Close Switch */
+#define ENUM_AFE_BUFSENCON_DISABLE           0x00000000            /*  V1P1LPADCEN: Disable ADC 1.8V LP Reference Buffer */
+#define ENUM_AFE_BUFSENCON_ENABLE            0x00000020            /*  V1P1LPADCEN: Enable ADC 1.8V LP Reference Buffer */
+#define ENUM_AFE_BUFSENCON_OFF               0x00000000            /*  V1P1HPADCEN: Disable 1.1V HP Common Mode Buffer */
+#define ENUM_AFE_BUFSENCON_ON                0x00000010            /*  V1P1HPADCEN: Enable 1.1V HP Common Mode Buffer */
+#define ENUM_AFE_BUFSENCON_OPEN              0x00000000            /*  V1P8HPADCCHGDIS: Open switch */
+#define ENUM_AFE_BUFSENCON_CLOSED            0x00000008            /*  V1P8HPADCCHGDIS: Close Switch */
+#define ENUM_AFE_BUFSENCON_LPADCREF_DIS      0x00000000            /*  V1P8LPADCEN: Disable LP 1.8V Reference Buffer */
+#define ENUM_AFE_BUFSENCON_LPADCREF_EN       0x00000004            /*  V1P8LPADCEN: Enable LP 1.8V Reference Buffer */
+#define ENUM_AFE_BUFSENCON_LIMIT_DIS         0x00000000            /*  V1P8HPADCILIMITEN: Disable buffer Current Limit */
+#define ENUM_AFE_BUFSENCON_LIMIT_EN          0x00000002            /*  V1P8HPADCILIMITEN: Enable buffer Current Limit */
+#define ENUM_AFE_BUFSENCON_HPBUF_DIS         0x00000000            /*  V1P8HPADCEN: Disable 1.8V HP ADC Reference Buffer */
+#define ENUM_AFE_BUFSENCON_HPBUF_EN          0x00000001            /*  V1P8HPADCEN: Enable 1.8V HP ADC Reference Buffer */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCCON                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCCON_GNPGA                16            /*  PGA Gain Setup */
+#define BITP_AFE_ADCCON_GNOFSELPGA           15            /*  Internal Offset/Gain Cancellation */
+#define BITP_AFE_ADCCON_GNOFFSEL             13            /*  Obsolete */
+#define BITP_AFE_ADCCON_MUXSELN               8            /*  Select Negative Input */
+#define BITP_AFE_ADCCON_MUXSELP               0            /*  Select Positive Input */
+#define BITM_AFE_ADCCON_GNPGA                0x00070000    /*  PGA Gain Setup */
+#define BITM_AFE_ADCCON_GNOFSELPGA           0x00008000    /*  Internal Offset/Gain Cancellation */
+#define BITM_AFE_ADCCON_GNOFFSEL             0x00006000    /*  Obsolete */
+#define BITM_AFE_ADCCON_MUXSELN              0x00001F00    /*  Select Negative Input */
+#define BITM_AFE_ADCCON_MUXSELP              0x0000003F    /*  Select Positive Input */
+#define ENUM_AFE_ADCCON_RESERVED             0x00000011            /*  MUXSELP: Reserved */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_DSWSTA                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_DSWSTA_D8STA                 7            /*  Status of D8 Switch. */
+#define BITP_AFE_DSWSTA_D7STA                 6            /*  Status of D7 Switch. */
+#define BITP_AFE_DSWSTA_D6STA                 5            /*  Status of D6 Switch. */
+#define BITP_AFE_DSWSTA_D5STA                 4            /*  Status of D5 Switch. */
+#define BITP_AFE_DSWSTA_D4STA                 3            /*  Status of D4 Switch. */
+#define BITP_AFE_DSWSTA_D3STA                 2            /*  Status of D3 Switch. */
+#define BITP_AFE_DSWSTA_D2STA                 1            /*  Status of D2 Switch. */
+#define BITP_AFE_DSWSTA_D1STA                 0            /*  Status of Dr0 Switch. */
+#define BITM_AFE_DSWSTA_D8STA                0x00000080    /*  Status of D8 Switch. */
+#define BITM_AFE_DSWSTA_D7STA                0x00000040    /*  Status of D7 Switch. */
+#define BITM_AFE_DSWSTA_D6STA                0x00000020    /*  Status of D6 Switch. */
+#define BITM_AFE_DSWSTA_D5STA                0x00000010    /*  Status of D5 Switch. */
+#define BITM_AFE_DSWSTA_D4STA                0x00000008    /*  Status of D4 Switch. */
+#define BITM_AFE_DSWSTA_D3STA                0x00000004    /*  Status of D3 Switch. */
+#define BITM_AFE_DSWSTA_D2STA                0x00000002    /*  Status of D2 Switch. */
+#define BITM_AFE_DSWSTA_D1STA                0x00000001    /*  Status of Dr0 Switch. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_PSWSTA                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_PSWSTA_PL2STA               14            /*  PL Switch Control */
+#define BITP_AFE_PSWSTA_PLSTA                13            /*  PL Switch Control */
+#define BITP_AFE_PSWSTA_P13STA               12            /*  Status of P13 Switch. */
+#define BITP_AFE_PSWSTA_P12STA               11            /*  Status of P12 Switch. */
+#define BITP_AFE_PSWSTA_P11STA               10            /*  Status of P11 Switch. */
+#define BITP_AFE_PSWSTA_P10STA                9            /*  Status of P10 Switch. */
+#define BITP_AFE_PSWSTA_P9STA                 8            /*  Status of P9 Switch. */
+#define BITP_AFE_PSWSTA_P8STA                 7            /*  Status of P8 Switch. */
+#define BITP_AFE_PSWSTA_P7STA                 6            /*  Status of P7 Switch. */
+#define BITP_AFE_PSWSTA_P6STA                 5            /*  Status of P6 Switch. */
+#define BITP_AFE_PSWSTA_P5STA                 4            /*  Status of P5 Switch. */
+#define BITP_AFE_PSWSTA_P4STA                 3            /*  Status of P4 Switch. */
+#define BITP_AFE_PSWSTA_P3STA                 2            /*  Status of P3 Switch. */
+#define BITP_AFE_PSWSTA_P2STA                 1            /*  Status of P2 Switch. */
+#define BITP_AFE_PSWSTA_PR0STA                0            /*  PR0 Switch Control */
+#define BITM_AFE_PSWSTA_PL2STA               0x00004000    /*  PL Switch Control */
+#define BITM_AFE_PSWSTA_PLSTA                0x00002000    /*  PL Switch Control */
+#define BITM_AFE_PSWSTA_P13STA               0x00001000    /*  Status of P13 Switch. */
+#define BITM_AFE_PSWSTA_P12STA               0x00000800    /*  Status of P12 Switch. */
+#define BITM_AFE_PSWSTA_P11STA               0x00000400    /*  Status of P11 Switch. */
+#define BITM_AFE_PSWSTA_P10STA               0x00000200    /*  Status of P10 Switch. */
+#define BITM_AFE_PSWSTA_P9STA                0x00000100    /*  Status of P9 Switch. */
+#define BITM_AFE_PSWSTA_P8STA                0x00000080    /*  Status of P8 Switch. */
+#define BITM_AFE_PSWSTA_P7STA                0x00000040    /*  Status of P7 Switch. */
+#define BITM_AFE_PSWSTA_P6STA                0x00000020    /*  Status of P6 Switch. */
+#define BITM_AFE_PSWSTA_P5STA                0x00000010    /*  Status of P5 Switch. */
+#define BITM_AFE_PSWSTA_P4STA                0x00000008    /*  Status of P4 Switch. */
+#define BITM_AFE_PSWSTA_P3STA                0x00000004    /*  Status of P3 Switch. */
+#define BITM_AFE_PSWSTA_P2STA                0x00000002    /*  Status of P2 Switch. */
+#define BITM_AFE_PSWSTA_PR0STA               0x00000001    /*  PR0 Switch Control */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_NSWSTA                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_NSWSTA_NL2STA               11            /*  Status of NL2 Switch. */
+#define BITP_AFE_NSWSTA_NLSTA                10            /*  Status of NL Switch. */
+#define BITP_AFE_NSWSTA_NR1STA                9            /*  Status of NR1 Switch. */
+#define BITP_AFE_NSWSTA_N9STA                 8            /*  Status of N9 Switch. */
+#define BITP_AFE_NSWSTA_N8STA                 7            /*  Status of N8 Switch. */
+#define BITP_AFE_NSWSTA_N7STA                 6            /*  Status of N7 Switch. */
+#define BITP_AFE_NSWSTA_N6STA                 5            /*  Status of N6 Switch. */
+#define BITP_AFE_NSWSTA_N5STA                 4            /*  Status of N5 Switch. */
+#define BITP_AFE_NSWSTA_N4STA                 3            /*  Status of N4 Switch. */
+#define BITP_AFE_NSWSTA_N3STA                 2            /*  Status of N3 Switch. */
+#define BITP_AFE_NSWSTA_N2STA                 1            /*  Status of N2 Switch. */
+#define BITP_AFE_NSWSTA_N1STA                 0            /*  Status of N1 Switch. */
+#define BITM_AFE_NSWSTA_NL2STA               0x00000800    /*  Status of NL2 Switch. */
+#define BITM_AFE_NSWSTA_NLSTA                0x00000400    /*  Status of NL Switch. */
+#define BITM_AFE_NSWSTA_NR1STA               0x00000200    /*  Status of NR1 Switch. */
+#define BITM_AFE_NSWSTA_N9STA                0x00000100    /*  Status of N9 Switch. */
+#define BITM_AFE_NSWSTA_N8STA                0x00000080    /*  Status of N8 Switch. */
+#define BITM_AFE_NSWSTA_N7STA                0x00000040    /*  Status of N7 Switch. */
+#define BITM_AFE_NSWSTA_N6STA                0x00000020    /*  Status of N6 Switch. */
+#define BITM_AFE_NSWSTA_N5STA                0x00000010    /*  Status of N5 Switch. */
+#define BITM_AFE_NSWSTA_N4STA                0x00000008    /*  Status of N4 Switch. */
+#define BITM_AFE_NSWSTA_N3STA                0x00000004    /*  Status of N3 Switch. */
+#define BITM_AFE_NSWSTA_N2STA                0x00000002    /*  Status of N2 Switch. */
+#define BITM_AFE_NSWSTA_N1STA                0x00000001    /*  Status of N1 Switch. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_TSWSTA                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_TSWSTA_TR1STA               11            /*  Status of TR1 Switch. */
+#define BITP_AFE_TSWSTA_T11STA               10            /*  Status of T11 Switch. */
+#define BITP_AFE_TSWSTA_T10STA                9            /*  Status of T10 Switch. */
+#define BITP_AFE_TSWSTA_T9STA                 8            /*  Status of T9 Switch. */
+#define BITP_AFE_TSWSTA_T8STA                 7            /*  Status of T8 Switch. */
+#define BITP_AFE_TSWSTA_T7STA                 6            /*  Status of T7 Switch. */
+#define BITP_AFE_TSWSTA_T6STA                 5            /*  Status of T6 Switch. */
+#define BITP_AFE_TSWSTA_T5STA                 4            /*  Status of T5 Switch. */
+#define BITP_AFE_TSWSTA_T4STA                 3            /*  Status of T4 Switch. */
+#define BITP_AFE_TSWSTA_T3STA                 2            /*  Status of T3 Switch. */
+#define BITP_AFE_TSWSTA_T2STA                 1            /*  Status of T2 Switch. */
+#define BITP_AFE_TSWSTA_T1STA                 0            /*  Status of T1 Switch. */
+#define BITM_AFE_TSWSTA_TR1STA               0x00000800    /*  Status of TR1 Switch. */
+#define BITM_AFE_TSWSTA_T11STA               0x00000400    /*  Status of T11 Switch. */
+#define BITM_AFE_TSWSTA_T10STA               0x00000200    /*  Status of T10 Switch. */
+#define BITM_AFE_TSWSTA_T9STA                0x00000100    /*  Status of T9 Switch. */
+#define BITM_AFE_TSWSTA_T8STA                0x00000080    /*  Status of T8 Switch. */
+#define BITM_AFE_TSWSTA_T7STA                0x00000040    /*  Status of T7 Switch. */
+#define BITM_AFE_TSWSTA_T6STA                0x00000020    /*  Status of T6 Switch. */
+#define BITM_AFE_TSWSTA_T5STA                0x00000010    /*  Status of T5 Switch. */
+#define BITM_AFE_TSWSTA_T4STA                0x00000008    /*  Status of T4 Switch. */
+#define BITM_AFE_TSWSTA_T3STA                0x00000004    /*  Status of T3 Switch. */
+#define BITM_AFE_TSWSTA_T2STA                0x00000002    /*  Status of T2 Switch. */
+#define BITM_AFE_TSWSTA_T1STA                0x00000001    /*  Status of T1 Switch. */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_STATSVAR                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_STATSVAR_VARIANCE            0            /*  Statistical Variance Value */
+#define BITM_AFE_STATSVAR_VARIANCE           0x7FFFFFFF    /*  Statistical Variance Value */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_STATSCON                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_STATSCON_STDDEV              7            /*  Standard Deviation Configuration */
+#define BITP_AFE_STATSCON_SAMPLENUM           4            /*  Sample Size */
+#define BITP_AFE_STATSCON_RESRVED             1            /*  Reserved */
+#define BITP_AFE_STATSCON_STATSEN             0            /*  Statistics Enable */
+#define BITM_AFE_STATSCON_STDDEV             0x00000F80    /*  Standard Deviation Configuration */
+#define BITM_AFE_STATSCON_SAMPLENUM          0x00000070    /*  Sample Size */
+#define BITM_AFE_STATSCON_RESRVED            0x0000000E    /*  Reserved */
+#define BITM_AFE_STATSCON_STATSEN            0x00000001    /*  Statistics Enable */
+#define ENUM_AFE_STATSCON_DIS                0x00000000            /*  STATSEN: Disable Statistics */
+#define ENUM_AFE_STATSCON_EN                 0x00000001            /*  STATSEN: Enable Statistics */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_STATSMEAN                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_STATSMEAN_MEAN               0            /*  Mean Output */
+#define BITM_AFE_STATSMEAN_MEAN              0x0000FFFF    /*  Mean Output */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_SEQ0INFO                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_SEQ0INFO_LEN                16            /*  SEQ0 Instruction Number */
+#define BITP_AFE_SEQ0INFO_ADDR                0            /*  SEQ0 Start Address */
+#define BITM_AFE_SEQ0INFO_LEN                0x07FF0000    /*  SEQ0 Instruction Number */
+#define BITM_AFE_SEQ0INFO_ADDR               0x000007FF    /*  SEQ0 Start Address */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_SEQ2INFO                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_SEQ2INFO_LEN                16            /*  SEQ2 Instruction Number */
+#define BITP_AFE_SEQ2INFO_ADDR                0            /*  SEQ2 Start Address */
+#define BITM_AFE_SEQ2INFO_LEN                0x07FF0000    /*  SEQ2 Instruction Number */
+#define BITM_AFE_SEQ2INFO_ADDR               0x000007FF    /*  SEQ2 Start Address */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_CMDFIFOWADDR                     Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_CMDFIFOWADDR_WADDR           0            /*  Write Address */
+#define BITM_AFE_CMDFIFOWADDR_WADDR          0x000007FF    /*  Write Address */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_CMDDATACON                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_CMDDATACON_DATAMEMMDE        9            /*  Data FIFO Mode Select */
+#define BITP_AFE_CMDDATACON_DATA_MEM_SEL      6            /*  Data FIFO Size Select */
+#define BITP_AFE_CMDDATACON_CMDMEMMDE         3            /*  This is Command Fifo Mode Register */
+#define BITP_AFE_CMDDATACON_CMD_MEM_SEL       0            /*  Command Memory Select */
+#define BITM_AFE_CMDDATACON_DATAMEMMDE       0x00000E00    /*  Data FIFO Mode Select */
+#define BITM_AFE_CMDDATACON_DATA_MEM_SEL     0x000001C0    /*  Data FIFO Size Select */
+#define BITM_AFE_CMDDATACON_CMDMEMMDE        0x00000038    /*  This is Command Fifo Mode Register */
+#define BITM_AFE_CMDDATACON_CMD_MEM_SEL      0x00000007    /*  Command Memory Select */
+#define ENUM_AFE_CMDDATACON_DFIFO            0x00000400            /*  DATAMEMMDE: FIFO MODE */
+#define ENUM_AFE_CMDDATACON_DSTM             0x00000600            /*  DATAMEMMDE: STREAM MODE */
+#define ENUM_AFE_CMDDATACON_DMEM32B          0x00000000            /*  DATA_MEM_SEL: 32B_1 Local Memory */
+#define ENUM_AFE_CMDDATACON_DMEM2K           0x00000040            /*  DATA_MEM_SEL: 2K_2 SRAM */
+#define ENUM_AFE_CMDDATACON_DMEM4K           0x00000080            /*  DATA_MEM_SEL: 2K_2~1 SRAM */
+#define ENUM_AFE_CMDDATACON_DMEM6K           0x000000C0            /*  DATA_MEM_SEL: 2K_2~0 SRAM */
+#define ENUM_AFE_CMDDATACON_CMEM             0x00000008            /*  CMDMEMMDE: MEMORY MODE */
+#define ENUM_AFE_CMDDATACON_CFIFO            0x00000010            /*  CMDMEMMDE: FIFO MODE */
+#define ENUM_AFE_CMDDATACON_CSTM             0x00000018            /*  CMDMEMMDE: STREAM MODE */
+#define ENUM_AFE_CMDDATACON_CMEM32B          0x00000000            /*  CMD_MEM_SEL: 32B_0 Local Memory */
+#define ENUM_AFE_CMDDATACON_CMEM2K           0x00000001            /*  CMD_MEM_SEL: 2K_0 SRAM */
+#define ENUM_AFE_CMDDATACON_CMEM4K           0x00000002            /*  CMD_MEM_SEL: 2K_0~1 SRAM */
+#define ENUM_AFE_CMDDATACON_CMEM6K           0x00000003            /*  CMD_MEM_SEL: 2K_0~2 SRAM */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_DATAFIFOTHRES                    Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_DATAFIFOTHRES_HIGHTHRES     16            /*  High Threshold */
+#define BITM_AFE_DATAFIFOTHRES_HIGHTHRES     0x07FF0000    /*  High Threshold */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_SEQ3INFO                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_SEQ3INFO_LEN                16            /*  SEQ3 Instruction Number */
+#define BITP_AFE_SEQ3INFO_ADDR                0            /*  SEQ3 Start Address */
+#define BITM_AFE_SEQ3INFO_LEN                0x07FF0000    /*  SEQ3 Instruction Number */
+#define BITM_AFE_SEQ3INFO_ADDR               0x000007FF    /*  SEQ3 Start Address */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_SEQ1INFO                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_SEQ1INFO_LEN                16            /*  SEQ1 Instruction Number */
+#define BITP_AFE_SEQ1INFO_ADDR                0            /*  SEQ1 Start Address */
+#define BITM_AFE_SEQ1INFO_LEN                0x07FF0000    /*  SEQ1 Instruction Number */
+#define BITM_AFE_SEQ1INFO_ADDR               0x000007FF    /*  SEQ1 Start Address */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_REPEATADCCNV                     Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_REPEATADCCNV_NUM             4            /*  Repeat Value */
+#define BITP_AFE_REPEATADCCNV_EN              0            /*  Enable Repeat ADC Conversions */
+#define BITM_AFE_REPEATADCCNV_NUM            0x00000FF0    /*  Repeat Value */
+#define BITM_AFE_REPEATADCCNV_EN             0x00000001    /*  Enable Repeat ADC Conversions */
+#define ENUM_AFE_REPEATADCCNV_DIS            0x00000000            /*  EN: Disable Repeat ADC Conversions */
+#define ENUM_AFE_REPEATADCCNV_EN             0x00000001            /*  EN: Enable Repeat ADC Conversions */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_FIFOCNTSTA                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_FIFOCNTSTA_DATAFIFOCNTSTA   16            /*  Current Number of Words in the Data FIFO */
+#define BITM_AFE_FIFOCNTSTA_DATAFIFOCNTSTA   0x07FF0000    /*  Current Number of Words in the Data FIFO */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_CALDATLOCK                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_CALDATLOCK_KEY               0            /*  Password for Calibration Data Registers */
+#define BITM_AFE_CALDATLOCK_KEY              0xFFFFFFFF    /*  Password for Calibration Data Registers */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCOFFSETHSTIA                   Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCOFFSETHSTIA_VALUE         0            /*  HSTIA Offset Calibration */
+#define BITM_AFE_ADCOFFSETHSTIA_VALUE        0x00007FFF    /*  HSTIA Offset Calibration */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCGAINTEMPSENS0                 Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCGAINTEMPSENS0_VALUE       0            /*  Gain Calibration Temp Sensor Channel */
+#define BITM_AFE_ADCGAINTEMPSENS0_VALUE      0x00007FFF    /*  Gain Calibration Temp Sensor Channel */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCOFFSETTEMPSENS0               Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCOFFSETTEMPSENS0_VALUE     0            /*  Offset Calibration Temp Sensor */
+#define BITM_AFE_ADCOFFSETTEMPSENS0_VALUE    0x00007FFF    /*  Offset Calibration Temp Sensor */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCGAINGN1                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCGAINGN1_VALUE             0            /*  Gain Calibration PGA Gain 1x */
+#define BITM_AFE_ADCGAINGN1_VALUE            0x00007FFF    /*  Gain Calibration PGA Gain 1x */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCOFFSETGN1                     Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCOFFSETGN1_VALUE           0            /*  Offset Calibration Gain1 */
+#define BITM_AFE_ADCOFFSETGN1_VALUE          0x00007FFF    /*  Offset Calibration Gain1 */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_DACGAIN                          Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_DACGAIN_VALUE                0            /*  HS DAC Gain Correction Factor */
+#define BITM_AFE_DACGAIN_VALUE               0x00000FFF    /*  HS DAC Gain Correction Factor */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_DACOFFSETATTEN                   Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_DACOFFSETATTEN_VALUE         0            /*  DAC Offset Correction Factor */
+#define BITM_AFE_DACOFFSETATTEN_VALUE        0x00000FFF    /*  DAC Offset Correction Factor */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_DACOFFSET                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_DACOFFSET_VALUE              0            /*  DAC Offset Correction Factor */
+#define BITM_AFE_DACOFFSET_VALUE             0x00000FFF    /*  DAC Offset Correction Factor */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCGAINGN1P5                     Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCGAINGN1P5_VALUE           0            /*  Gain Calibration PGA Gain 1.5x */
+#define BITM_AFE_ADCGAINGN1P5_VALUE          0x00007FFF    /*  Gain Calibration PGA Gain 1.5x */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCGAINGN2                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCGAINGN2_VALUE             0            /*  Gain Calibration PGA Gain 2x */
+#define BITM_AFE_ADCGAINGN2_VALUE            0x00007FFF    /*  Gain Calibration PGA Gain 2x */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCGAINGN4                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCGAINGN4_VALUE             0            /*  Gain Calibration PGA Gain 4x */
+#define BITM_AFE_ADCGAINGN4_VALUE            0x00007FFF    /*  Gain Calibration PGA Gain 4x */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCPGAOFFSETCANCEL               Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCPGAOFFSETCANCEL_OFFSETCANCEL  0            /*  Offset Cancellation */
+#define BITM_AFE_ADCPGAOFFSETCANCEL_OFFSETCANCEL 0x00007FFF    /*  Offset Cancellation */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCGNHSTIA                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCGNHSTIA_VALUE             0            /*  Gain Error Calibration HS TIA Channel */
+#define BITM_AFE_ADCGNHSTIA_VALUE            0x00007FFF    /*  Gain Error Calibration HS TIA Channel */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCOFFSETLPTIA0                  Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCOFFSETLPTIA0_VALUE        0            /*  Offset Calibration for ULP-TIA0 */
+#define BITM_AFE_ADCOFFSETLPTIA0_VALUE       0x00007FFF    /*  Offset Calibration for ULP-TIA0 */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCGNLPTIA0                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCGNLPTIA0_VALUE            0            /*  Gain Error Calibration ULPTIA0 */
+#define BITM_AFE_ADCGNLPTIA0_VALUE           0x00007FFF    /*  Gain Error Calibration ULPTIA0 */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCPGAGN4OFCAL                   Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCPGAGN4OFCAL_ADCGAINAUX    0            /*  DC Calibration Gain=4 */
+#define BITM_AFE_ADCPGAGN4OFCAL_ADCGAINAUX   0x00007FFF    /*  DC Calibration Gain=4 */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCGAINGN9                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCGAINGN9_VALUE             0            /*  Gain Calibration PGA Gain 9x */
+#define BITM_AFE_ADCGAINGN9_VALUE            0x00007FFF    /*  Gain Calibration PGA Gain 9x */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCOFFSETEMPSENS1                Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCOFFSETEMPSENS1_VALUE      0            /*  Offset Calibration Temp Sensor */
+#define BITM_AFE_ADCOFFSETEMPSENS1_VALUE     0x00007FFF    /*  Offset Calibration Temp Sensor */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCGAINDIOTEMPSENS               Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCGAINDIOTEMPSENS_VALUE     0            /*  Gain Calibration for Diode Temp Sensor */
+#define BITM_AFE_ADCGAINDIOTEMPSENS_VALUE    0x00007FFF    /*  Gain Calibration for Diode Temp Sensor */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_DACOFFSETATTENHP                 Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_DACOFFSETATTENHP_VALUE       0            /*  DAC Offset Correction Factor */
+#define BITM_AFE_DACOFFSETATTENHP_VALUE      0x00000FFF    /*  DAC Offset Correction Factor */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_DACOFFSETHP                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_DACOFFSETHP_VALUE            0            /*  DAC Offset Correction Factor */
+#define BITM_AFE_DACOFFSETHP_VALUE           0x00000FFF    /*  DAC Offset Correction Factor */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCOFFSETLPTIA1                  Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCOFFSETLPTIA1_VALUE        0            /*  Offset Calibration for ULP-TIA1 */
+#define BITM_AFE_ADCOFFSETLPTIA1_VALUE       (_ADI_MSK_3(0x00007FFF,0x00007FFFUL, uint32_t  ))    /*  Offset Calibration for ULP-TIA1 */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCGNLPTIA1                      Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCGNLPTIA1_ULPTIA1GN        0            /*  Gain Calibration ULP-TIA1 */
+#define BITM_AFE_ADCGNLPTIA1_ULPTIA1GN       0x00007FFF    /*  Gain Calibration ULP-TIA1 */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCOFFSETGN2                     Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCOFFSETGN2_VALUE           0            /*  Offset Calibration Auxiliary Channel (PGA Gain =2) */
+#define BITM_AFE_ADCOFFSETGN2_VALUE          0x00007FFF    /*  Offset Calibration Auxiliary Channel (PGA Gain =2) */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCOFFSETGN1P5                   Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCOFFSETGN1P5_VALUE         0            /*  Offset Calibration Gain1.5 */
+#define BITM_AFE_ADCOFFSETGN1P5_VALUE        0x00007FFF    /*  Offset Calibration Gain1.5 */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCOFFSETGN9                     Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCOFFSETGN9_VALUE           0            /*  Offset Calibration Gain9 */
+#define BITM_AFE_ADCOFFSETGN9_VALUE          0x00007FFF    /*  Offset Calibration Gain9 */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCOFFSETGN4                     Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCOFFSETGN4_VALUE           0            /*  Offset Calibration Gain4 */
+#define BITM_AFE_ADCOFFSETGN4_VALUE          0x00007FFF    /*  Offset Calibration Gain4 */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_PMBW                             Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_PMBW_SYSBW                   2            /*  Configure System Bandwidth */
+#define BITP_AFE_PMBW_SYSHP                   0            /*  Set High Speed DAC and ADC in High Power Mode */
+#define BITM_AFE_PMBW_SYSBW                  0x0000000C    /*  Configure System Bandwidth */
+#define BITM_AFE_PMBW_SYSHP                  0x00000001    /*  Set High Speed DAC and ADC in High Power Mode */
+#define ENUM_AFE_PMBW_BWNA                   0x00000000            /*  SYSBW: no action for system configuration */
+#define ENUM_AFE_PMBW_BW50                   0x00000004            /*  SYSBW: 50kHz -3dB bandwidth */
+#define ENUM_AFE_PMBW_BW100                  0x00000008            /*  SYSBW: 100kHz -3dB bandwidth */
+#define ENUM_AFE_PMBW_BW250                  0x0000000C            /*  SYSBW: 250kHz -3dB bandwidth */
+#define ENUM_AFE_PMBW_LP                     0x00000000            /*  SYSHP: LP mode */
+#define ENUM_AFE_PMBW_HP                     0x00000001            /*  SYSHP: HP mode */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_SWMUX                           Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_SWMUX_CMMUX                 3            /*  CM Resistor Select for Ain2, Ain3 */
+#define BITM_AFE_SWMUX_CMMUX                0x00000008    /*  CM Resistor Select for Ain2, Ain3 */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_AFE_TEMPSEN_DIO                  Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_AFE_TEMPSEN_DIO_TSDIO_PD    17            /*  Power Down Control */
+#define BITP_AFE_AFE_TEMPSEN_DIO_TSDIO_EN    16            /*  Test Signal Enable */
+#define BITP_AFE_AFE_TEMPSEN_DIO_TSDIO_CON    0            /*  Bias Current Selection */
+#define BITM_AFE_AFE_TEMPSEN_DIO_TSDIO_PD    0x00020000    /*  Power Down Control */
+#define BITM_AFE_AFE_TEMPSEN_DIO_TSDIO_EN    0x00010000    /*  Test Signal Enable */
+#define BITM_AFE_AFE_TEMPSEN_DIO_TSDIO_CON   0x0000FFFF    /*  Bias Current Selection */
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          AFE_ADCBUFCON                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_AFE_ADCBUFCON_AMPDIS             4            /*  Disable OpAmp. */
+#define BITP_AFE_ADCBUFCON_CHOPDIS            0            /*  Disable Chop */
+#define BITM_AFE_ADCBUFCON_AMPDIS            0x000001F0    /*  Disable OpAmp. */
+#define BITM_AFE_ADCBUFCON_CHOPDIS           0x0000000F    /*  Disable Chop */
+
+
+/* ============================================================================================================================
+        Interrupt Controller Register Map
+   ============================================================================================================================ */
+
+/* ============================================================================================================================
+        INTC
+   ============================================================================================================================ */
+#define REG_INTC_INTCPOL_RESET               0x00000000            /*      Reset Value for INTCPOL  */
+#define REG_INTC_INTCPOL                     0x00003000            /*  INTC Interrupt Polarity Register */
+#define REG_INTC_INTCCLR_RESET               0x00000000            /*      Reset Value for INTCCLR  */
+#define REG_INTC_INTCCLR                     0x00003004            /*  INTC Interrupt Clear Register */
+#define REG_INTC_INTCSEL0_RESET              0x00002000            /*      Reset Value for INTCSEL0  */
+#define REG_INTC_INTCSEL0                    0x00003008            /*  INTC INT0 Select Register */
+#define REG_INTC_INTCSEL1_RESET              0x00000000            /*      Reset Value for INTCSEL1  */
+#define REG_INTC_INTCSEL1                    0x0000300C            /*  INTC INT1 Select Register */
+#define REG_INTC_INTCFLAG0_RESET             0x00000000            /*      Reset Value for INTCFLAG0  */
+#define REG_INTC_INTCFLAG0                   0x00003010            /*  INTC INT0 FLAG Register */
+#define REG_INTC_INTCFLAG1_RESET             0x00000000            /*      Reset Value for INTCFLAG1  */
+#define REG_INTC_INTCFLAG1                   0x00003014            /*  INTC INT1 FLAG Register */
+
+/* ============================================================================================================================
+        INTC Register BitMasks, Positions & Enumerations 
+   ============================================================================================================================ */
+/* -------------------------------------------------------------------------------------------------------------------------
+          INTC_INTCPOL                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_INTC_INTCPOL_INTPOL              0
+#define BITM_INTC_INTCPOL_INTPOL             0x00000001
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          INTC_INTCCLR                         Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_INTC_INTCCLR_INTCLR31           31
+#define BITP_INTC_INTCCLR_INTCLR30           30
+#define BITP_INTC_INTCCLR_INTCLR29           29
+#define BITP_INTC_INTCCLR_INTCLR28           28
+#define BITP_INTC_INTCCLR_INTCLR27           27
+#define BITP_INTC_INTCCLR_INTCLR26           26
+#define BITP_INTC_INTCCLR_INTCLR25           25
+#define BITP_INTC_INTCCLR_INTCLR24           24
+#define BITP_INTC_INTCCLR_INTCLR23           23
+#define BITP_INTC_INTCCLR_INTCLR22           22
+#define BITP_INTC_INTCCLR_INTCLR21           21
+#define BITP_INTC_INTCCLR_INTCLR20           20
+#define BITP_INTC_INTCCLR_INTCLR19           19
+#define BITP_INTC_INTCCLR_INTCLR18           18
+#define BITP_INTC_INTCCLR_INTCLR17           17
+#define BITP_INTC_INTCCLR_INTCLR16           16
+#define BITP_INTC_INTCCLR_INTCLR15           15
+#define BITP_INTC_INTCCLR_INTCLR14           14
+#define BITP_INTC_INTCCLR_INTCLR13           13
+#define BITP_INTC_INTCCLR_INTCLR12           12            /*  Custom IRQ 3. Write 1 to clear. */
+#define BITP_INTC_INTCCLR_INTCLR11           11            /*  Custom IRQ 2. Write 1 to clear. */
+#define BITP_INTC_INTCCLR_INTCLR10           10            /*  Custom IRQ 1. Write 1 to clear. */
+#define BITP_INTC_INTCCLR_INTCLR9             9            /*  Custom IRQ 0. Write 1 to clear */
+#define BITP_INTC_INTCCLR_INTCLR8             8
+#define BITP_INTC_INTCCLR_INTCLR7             7
+#define BITP_INTC_INTCCLR_INTCLR6             6
+#define BITP_INTC_INTCCLR_INTCLR5             5
+#define BITP_INTC_INTCCLR_INTCLR4             4
+#define BITP_INTC_INTCCLR_INTCLR3             3
+#define BITP_INTC_INTCCLR_INTCLR2             2
+#define BITP_INTC_INTCCLR_INTCLR1             1
+#define BITP_INTC_INTCCLR_INTCLR0             0
+#define BITM_INTC_INTCCLR_INTCLR31           0x80000000
+#define BITM_INTC_INTCCLR_INTCLR30           0x40000000
+#define BITM_INTC_INTCCLR_INTCLR29           0x20000000
+#define BITM_INTC_INTCCLR_INTCLR28           0x10000000
+#define BITM_INTC_INTCCLR_INTCLR27           0x08000000
+#define BITM_INTC_INTCCLR_INTCLR26           0x04000000
+#define BITM_INTC_INTCCLR_INTCLR25           0x02000000
+#define BITM_INTC_INTCCLR_INTCLR24           0x01000000
+#define BITM_INTC_INTCCLR_INTCLR23           0x00800000
+#define BITM_INTC_INTCCLR_INTCLR22           0x00400000
+#define BITM_INTC_INTCCLR_INTCLR21           0x00200000
+#define BITM_INTC_INTCCLR_INTCLR20           0x00100000
+#define BITM_INTC_INTCCLR_INTCLR19           0x00080000
+#define BITM_INTC_INTCCLR_INTCLR18           0x00040000
+#define BITM_INTC_INTCCLR_INTCLR17           0x00020000
+#define BITM_INTC_INTCCLR_INTCLR16           0x00010000
+#define BITM_INTC_INTCCLR_INTCLR15           0x00008000
+#define BITM_INTC_INTCCLR_INTCLR14           0x00004000
+#define BITM_INTC_INTCCLR_INTCLR13           0x00002000
+#define BITM_INTC_INTCCLR_INTCLR12           0x00001000    /*  Custom IRQ 3. Write 1 to clear. */
+#define BITM_INTC_INTCCLR_INTCLR11           0x00000800    /*  Custom IRQ 2. Write 1 to clear. */
+#define BITM_INTC_INTCCLR_INTCLR10           0x00000400    /*  Custom IRQ 1. Write 1 to clear. */
+#define BITM_INTC_INTCCLR_INTCLR9            0x00000200    /*  Custom IRQ 0. Write 1 to clear */
+#define BITM_INTC_INTCCLR_INTCLR8            0x00000100
+#define BITM_INTC_INTCCLR_INTCLR7            0x00000080
+#define BITM_INTC_INTCCLR_INTCLR6            0x00000040
+#define BITM_INTC_INTCCLR_INTCLR5            0x00000020
+#define BITM_INTC_INTCCLR_INTCLR4            0x00000010
+#define BITM_INTC_INTCCLR_INTCLR3            0x00000008
+#define BITM_INTC_INTCCLR_INTCLR2            0x00000004
+#define BITM_INTC_INTCCLR_INTCLR1            0x00000002
+#define BITM_INTC_INTCCLR_INTCLR0            0x00000001
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          INTC_INTCSEL0                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_INTC_INTCSEL0_INTSEL31          31
+#define BITP_INTC_INTCSEL0_INTSEL30          30
+#define BITP_INTC_INTCSEL0_INTSEL29          29
+#define BITP_INTC_INTCSEL0_INTSEL28          28
+#define BITP_INTC_INTCSEL0_INTSEL27          27
+#define BITP_INTC_INTCSEL0_INTSEL26          26
+#define BITP_INTC_INTCSEL0_INTSEL25          25
+#define BITP_INTC_INTCSEL0_INTSEL24          24
+#define BITP_INTC_INTCSEL0_INTSEL23          23
+#define BITP_INTC_INTCSEL0_INTSEL22          22
+#define BITP_INTC_INTCSEL0_INTSEL21          21
+#define BITP_INTC_INTCSEL0_INTSEL20          20
+#define BITP_INTC_INTCSEL0_INTSEL19          19
+#define BITP_INTC_INTCSEL0_INTSEL18          18
+#define BITP_INTC_INTCSEL0_INTSEL17          17
+#define BITP_INTC_INTCSEL0_INTSEL16          16
+#define BITP_INTC_INTCSEL0_INTSEL15          15
+#define BITP_INTC_INTCSEL0_INTSEL14          14
+#define BITP_INTC_INTCSEL0_INTSEL13          13
+#define BITP_INTC_INTCSEL0_INTSEL12          12            /*  Custom IRQ 3 Enable */
+#define BITP_INTC_INTCSEL0_INTSEL11          11            /*  Custom IRQ 2 Enable */
+#define BITP_INTC_INTCSEL0_INTSEL10          10            /*  Custom IRQ 1 Enable */
+#define BITP_INTC_INTCSEL0_INTSEL9            9            /*  Custom IRQ 0 Enable */
+#define BITP_INTC_INTCSEL0_INTSEL8            8
+#define BITP_INTC_INTCSEL0_INTSEL7            7
+#define BITP_INTC_INTCSEL0_INTSEL6            6
+#define BITP_INTC_INTCSEL0_INTSEL5            5
+#define BITP_INTC_INTCSEL0_INTSEL4            4
+#define BITP_INTC_INTCSEL0_INTSEL3            3
+#define BITP_INTC_INTCSEL0_INTSEL2            2
+#define BITP_INTC_INTCSEL0_INTSEL1            1
+#define BITP_INTC_INTCSEL0_INTSEL0            0
+#define BITM_INTC_INTCSEL0_INTSEL31          0x80000000
+#define BITM_INTC_INTCSEL0_INTSEL30          0x40000000
+#define BITM_INTC_INTCSEL0_INTSEL29          0x20000000
+#define BITM_INTC_INTCSEL0_INTSEL28          0x10000000
+#define BITM_INTC_INTCSEL0_INTSEL27          0x08000000
+#define BITM_INTC_INTCSEL0_INTSEL26          0x04000000
+#define BITM_INTC_INTCSEL0_INTSEL25          0x02000000
+#define BITM_INTC_INTCSEL0_INTSEL24          0x01000000
+#define BITM_INTC_INTCSEL0_INTSEL23          0x00800000
+#define BITM_INTC_INTCSEL0_INTSEL22          0x00400000
+#define BITM_INTC_INTCSEL0_INTSEL21          0x00200000
+#define BITM_INTC_INTCSEL0_INTSEL20          0x00100000
+#define BITM_INTC_INTCSEL0_INTSEL19          0x00080000
+#define BITM_INTC_INTCSEL0_INTSEL18          0x00040000
+#define BITM_INTC_INTCSEL0_INTSEL17          0x00020000
+#define BITM_INTC_INTCSEL0_INTSEL16          0x00010000
+#define BITM_INTC_INTCSEL0_INTSEL15          0x00008000
+#define BITM_INTC_INTCSEL0_INTSEL14          0x00004000
+#define BITM_INTC_INTCSEL0_INTSEL13          0x00002000
+#define BITM_INTC_INTCSEL0_INTSEL12          0x00001000    /*  Custom IRQ 3 Enable */
+#define BITM_INTC_INTCSEL0_INTSEL11          0x00000800    /*  Custom IRQ 2 Enable */
+#define BITM_INTC_INTCSEL0_INTSEL10          0x00000400    /*  Custom IRQ 1 Enable */
+#define BITM_INTC_INTCSEL0_INTSEL9           0x00000200    /*  Custom IRQ 0 Enable */
+#define BITM_INTC_INTCSEL0_INTSEL8           0x00000100
+#define BITM_INTC_INTCSEL0_INTSEL7           0x00000080
+#define BITM_INTC_INTCSEL0_INTSEL6           0x00000040
+#define BITM_INTC_INTCSEL0_INTSEL5           0x00000020
+#define BITM_INTC_INTCSEL0_INTSEL4           0x00000010
+#define BITM_INTC_INTCSEL0_INTSEL3           0x00000008
+#define BITM_INTC_INTCSEL0_INTSEL2           0x00000004
+#define BITM_INTC_INTCSEL0_INTSEL1           0x00000002
+#define BITM_INTC_INTCSEL0_INTSEL0           0x00000001
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          INTC_INTCSEL1                        Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_INTC_INTCSEL1_INTSEL31          31
+#define BITP_INTC_INTCSEL1_INTSEL30          30
+#define BITP_INTC_INTCSEL1_INTSEL29          29
+#define BITP_INTC_INTCSEL1_INTSEL28          28
+#define BITP_INTC_INTCSEL1_INTSEL27          27
+#define BITP_INTC_INTCSEL1_INTSEL26          26
+#define BITP_INTC_INTCSEL1_INTSEL25          25
+#define BITP_INTC_INTCSEL1_INTSEL24          24
+#define BITP_INTC_INTCSEL1_INTSEL23          23
+#define BITP_INTC_INTCSEL1_INTSEL22          22
+#define BITP_INTC_INTCSEL1_INTSEL21          21
+#define BITP_INTC_INTCSEL1_INTSEL20          20
+#define BITP_INTC_INTCSEL1_INTSEL19          19
+#define BITP_INTC_INTCSEL1_INTSEL18          18
+#define BITP_INTC_INTCSEL1_INTSEL17          17
+#define BITP_INTC_INTCSEL1_INTSEL16          16
+#define BITP_INTC_INTCSEL1_INTSEL15          15
+#define BITP_INTC_INTCSEL1_INTSEL14          14
+#define BITP_INTC_INTCSEL1_INTSEL13          13
+#define BITP_INTC_INTCSEL1_INTSEL12          12            /*  Custom IRQ 3 Enable */
+#define BITP_INTC_INTCSEL1_INTSEL11          11            /*  Custom IRQ 2 Enable */
+#define BITP_INTC_INTCSEL1_INTSEL10          10            /*  Custom IRQ 1 Enable */
+#define BITP_INTC_INTCSEL1_INTSEL9            9            /*  Custom IRQ 0 Enable */
+#define BITP_INTC_INTCSEL1_INTSEL8            8
+#define BITP_INTC_INTCSEL1_INTSEL7            7
+#define BITP_INTC_INTCSEL1_INTSEL6            6
+#define BITP_INTC_INTCSEL1_INTSEL5            5
+#define BITP_INTC_INTCSEL1_INTSEL4            4
+#define BITP_INTC_INTCSEL1_INTSEL3            3
+#define BITP_INTC_INTCSEL1_INTSEL2            2
+#define BITP_INTC_INTCSEL1_INTSEL1            1
+#define BITP_INTC_INTCSEL1_INTSEL0            0
+#define BITM_INTC_INTCSEL1_INTSEL31          0x80000000
+#define BITM_INTC_INTCSEL1_INTSEL30          0x40000000
+#define BITM_INTC_INTCSEL1_INTSEL29          0x20000000
+#define BITM_INTC_INTCSEL1_INTSEL28          0x10000000
+#define BITM_INTC_INTCSEL1_INTSEL27          0x08000000
+#define BITM_INTC_INTCSEL1_INTSEL26          0x04000000
+#define BITM_INTC_INTCSEL1_INTSEL25          0x02000000
+#define BITM_INTC_INTCSEL1_INTSEL24          0x01000000
+#define BITM_INTC_INTCSEL1_INTSEL23          0x00800000
+#define BITM_INTC_INTCSEL1_INTSEL22          0x00400000
+#define BITM_INTC_INTCSEL1_INTSEL21          0x00200000
+#define BITM_INTC_INTCSEL1_INTSEL20          0x00100000
+#define BITM_INTC_INTCSEL1_INTSEL19          0x00080000
+#define BITM_INTC_INTCSEL1_INTSEL18          0x00040000
+#define BITM_INTC_INTCSEL1_INTSEL17          0x00020000
+#define BITM_INTC_INTCSEL1_INTSEL16          0x00010000
+#define BITM_INTC_INTCSEL1_INTSEL15          0x00008000
+#define BITM_INTC_INTCSEL1_INTSEL14          0x00004000
+#define BITM_INTC_INTCSEL1_INTSEL13          0x00002000
+#define BITM_INTC_INTCSEL1_INTSEL12          0x00001000    /*  Custom IRQ 3 Enable */
+#define BITM_INTC_INTCSEL1_INTSEL11          0x00000800    /*  Custom IRQ 2 Enable */
+#define BITM_INTC_INTCSEL1_INTSEL10          0x00000400    /*  Custom IRQ 1 Enable */
+#define BITM_INTC_INTCSEL1_INTSEL9           0x00000200    /*  Custom IRQ 0 Enable */
+#define BITM_INTC_INTCSEL1_INTSEL8           0x00000100
+#define BITM_INTC_INTCSEL1_INTSEL7           0x00000080
+#define BITM_INTC_INTCSEL1_INTSEL6           0x00000040
+#define BITM_INTC_INTCSEL1_INTSEL5           0x00000020
+#define BITM_INTC_INTCSEL1_INTSEL4           0x00000010
+#define BITM_INTC_INTCSEL1_INTSEL3           0x00000008
+#define BITM_INTC_INTCSEL1_INTSEL2           0x00000004
+#define BITM_INTC_INTCSEL1_INTSEL1           0x00000002
+#define BITM_INTC_INTCSEL1_INTSEL0           0x00000001
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          INTC_INTCFLAG0                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_INTC_INTCFLAG0_FLAG31           31
+#define BITP_INTC_INTCFLAG0_FLAG30           30
+#define BITP_INTC_INTCFLAG0_FLAG29           29
+#define BITP_INTC_INTCFLAG0_FLAG28           28
+#define BITP_INTC_INTCFLAG0_FLAG27           27
+#define BITP_INTC_INTCFLAG0_FLAG26           26
+#define BITP_INTC_INTCFLAG0_FLAG25           25
+#define BITP_INTC_INTCFLAG0_FLAG24           24
+#define BITP_INTC_INTCFLAG0_FLAG23           23
+#define BITP_INTC_INTCFLAG0_FLAG22           22
+#define BITP_INTC_INTCFLAG0_FLAG21           21
+#define BITP_INTC_INTCFLAG0_FLAG20           20
+#define BITP_INTC_INTCFLAG0_FLAG19           19
+#define BITP_INTC_INTCFLAG0_FLAG18           18
+#define BITP_INTC_INTCFLAG0_FLAG17           17
+#define BITP_INTC_INTCFLAG0_FLAG16           16
+#define BITP_INTC_INTCFLAG0_FLAG15           15
+#define BITP_INTC_INTCFLAG0_FLAG14           14
+#define BITP_INTC_INTCFLAG0_FLAG13           13
+#define BITP_INTC_INTCFLAG0_FLAG12           12            /*  Custom IRQ 3 Status */
+#define BITP_INTC_INTCFLAG0_FLAG11           11            /*  Custom IRQ 2 Status */
+#define BITP_INTC_INTCFLAG0_FLAG10           10            /*  Custom IRQ 1 Status */
+#define BITP_INTC_INTCFLAG0_FLAG9             9            /*  Custom IRQ 0 Status */
+#define BITP_INTC_INTCFLAG0_FLAG8             8            /*  Variance IRQ status. */
+#define BITP_INTC_INTCFLAG0_FLAG7             7
+#define BITP_INTC_INTCFLAG0_FLAG6             6
+#define BITP_INTC_INTCFLAG0_FLAG5             5
+#define BITP_INTC_INTCFLAG0_FLAG4             4
+#define BITP_INTC_INTCFLAG0_FLAG3             3
+#define BITP_INTC_INTCFLAG0_FLAG2             2
+#define BITP_INTC_INTCFLAG0_FLAG1             1
+#define BITP_INTC_INTCFLAG0_FLAG0             0
+#define BITM_INTC_INTCFLAG0_FLAG31           0x80000000
+#define BITM_INTC_INTCFLAG0_FLAG30           0x40000000
+#define BITM_INTC_INTCFLAG0_FLAG29           0x20000000
+#define BITM_INTC_INTCFLAG0_FLAG28           0x10000000
+#define BITM_INTC_INTCFLAG0_FLAG27           0x08000000
+#define BITM_INTC_INTCFLAG0_FLAG26           0x04000000
+#define BITM_INTC_INTCFLAG0_FLAG25           0x02000000
+#define BITM_INTC_INTCFLAG0_FLAG24           0x01000000
+#define BITM_INTC_INTCFLAG0_FLAG23           0x00800000
+#define BITM_INTC_INTCFLAG0_FLAG22           0x00400000
+#define BITM_INTC_INTCFLAG0_FLAG21           0x00200000
+#define BITM_INTC_INTCFLAG0_FLAG20           0x00100000
+#define BITM_INTC_INTCFLAG0_FLAG19           0x00080000
+#define BITM_INTC_INTCFLAG0_FLAG18           0x00040000
+#define BITM_INTC_INTCFLAG0_FLAG17           0x00020000
+#define BITM_INTC_INTCFLAG0_FLAG16           0x00010000
+#define BITM_INTC_INTCFLAG0_FLAG15           0x00008000
+#define BITM_INTC_INTCFLAG0_FLAG14           0x00004000
+#define BITM_INTC_INTCFLAG0_FLAG13           0x00002000
+#define BITM_INTC_INTCFLAG0_FLAG12           0x00001000    /*  Custom IRQ 3 Status */
+#define BITM_INTC_INTCFLAG0_FLAG11           0x00000800    /*  Custom IRQ 2 Status */
+#define BITM_INTC_INTCFLAG0_FLAG10           0x00000400    /*  Custom IRQ 1 Status */
+#define BITM_INTC_INTCFLAG0_FLAG9            0x00000200    /*  Custom IRQ 0 Status */
+#define BITM_INTC_INTCFLAG0_FLAG8            0x00000100    /*  Variance IRQ status. */
+#define BITM_INTC_INTCFLAG0_FLAG7            0x00000080
+#define BITM_INTC_INTCFLAG0_FLAG6            0x00000040
+#define BITM_INTC_INTCFLAG0_FLAG5            0x00000020
+#define BITM_INTC_INTCFLAG0_FLAG4            0x00000010
+#define BITM_INTC_INTCFLAG0_FLAG3            0x00000008
+#define BITM_INTC_INTCFLAG0_FLAG2            0x00000004
+#define BITM_INTC_INTCFLAG0_FLAG1            0x00000002
+#define BITM_INTC_INTCFLAG0_FLAG0            0x00000001
+
+/* -------------------------------------------------------------------------------------------------------------------------
+          INTC_INTCFLAG1                       Pos/Masks         Description
+   ------------------------------------------------------------------------------------------------------------------------- */
+#define BITP_INTC_INTCFLAG1_FLAG31           31
+#define BITP_INTC_INTCFLAG1_FLAG30           30
+#define BITP_INTC_INTCFLAG1_FLAG29           29
+#define BITP_INTC_INTCFLAG1_FLAG28           28
+#define BITP_INTC_INTCFLAG1_FLAG27           27
+#define BITP_INTC_INTCFLAG1_FLAG26           26
+#define BITP_INTC_INTCFLAG1_FLAG25           25
+#define BITP_INTC_INTCFLAG1_FLAG24           24
+#define BITP_INTC_INTCFLAG1_FLAG23           23
+#define BITP_INTC_INTCFLAG1_FLAG22           22
+#define BITP_INTC_INTCFLAG1_FLAG21           21
+#define BITP_INTC_INTCFLAG1_FLAG20           20
+#define BITP_INTC_INTCFLAG1_FLAG19           19
+#define BITP_INTC_INTCFLAG1_FLAG18           18
+#define BITP_INTC_INTCFLAG1_FLAG17           17
+#define BITP_INTC_INTCFLAG1_FLAG16           16
+#define BITP_INTC_INTCFLAG1_FLAG15           15
+#define BITP_INTC_INTCFLAG1_FLAG14           14
+#define BITP_INTC_INTCFLAG1_FLAG13           13
+#define BITP_INTC_INTCFLAG1_FLAG12           12            /*  Custom IRQ 3 Status */
+#define BITP_INTC_INTCFLAG1_FLAG11           11            /*  Custom IRQ 2 Status */
+#define BITP_INTC_INTCFLAG1_FLAG10           10            /*  Custom IRQ 1 Status */
+#define BITP_INTC_INTCFLAG1_FLAG9             9            /*  Custom IRQ 0 Status */
+#define BITP_INTC_INTCFLAG1_FLAG8             8            /*  Variance IRQ status. */
+#define BITP_INTC_INTCFLAG1_FLAG7             7
+#define BITP_INTC_INTCFLAG1_FLAG6             6
+#define BITP_INTC_INTCFLAG1_FLAG5             5
+#define BITP_INTC_INTCFLAG1_FLAG4             4
+#define BITP_INTC_INTCFLAG1_FLAG3             3
+#define BITP_INTC_INTCFLAG1_FLAG2             2
+#define BITP_INTC_INTCFLAG1_FLAG1             1
+#define BITP_INTC_INTCFLAG1_FLAG0             0
+#define BITM_INTC_INTCFLAG1_FLAG31           0x80000000
+#define BITM_INTC_INTCFLAG1_FLAG30           0x40000000
+#define BITM_INTC_INTCFLAG1_FLAG29           0x20000000
+#define BITM_INTC_INTCFLAG1_FLAG28           0x10000000
+#define BITM_INTC_INTCFLAG1_FLAG27           0x08000000
+#define BITM_INTC_INTCFLAG1_FLAG26           0x04000000
+#define BITM_INTC_INTCFLAG1_FLAG25           0x02000000
+#define BITM_INTC_INTCFLAG1_FLAG24           0x01000000
+#define BITM_INTC_INTCFLAG1_FLAG23           0x00800000
+#define BITM_INTC_INTCFLAG1_FLAG22           0x00400000
+#define BITM_INTC_INTCFLAG1_FLAG21           0x00200000
+#define BITM_INTC_INTCFLAG1_FLAG20           0x00100000
+#define BITM_INTC_INTCFLAG1_FLAG19           0x00080000
+#define BITM_INTC_INTCFLAG1_FLAG18           0x00040000
+#define BITM_INTC_INTCFLAG1_FLAG17           0x00020000
+#define BITM_INTC_INTCFLAG1_FLAG16           0x00010000
+#define BITM_INTC_INTCFLAG1_FLAG15           0x00008000
+#define BITM_INTC_INTCFLAG1_FLAG14           0x00004000
+#define BITM_INTC_INTCFLAG1_FLAG13           0x00002000
+#define BITM_INTC_INTCFLAG1_FLAG12           0x00001000    /*  Custom IRQ 3 Status */
+#define BITM_INTC_INTCFLAG1_FLAG11           0x00000800    /*  Custom IRQ 2 Status */
+#define BITM_INTC_INTCFLAG1_FLAG10           0x00000400    /*  Custom IRQ 1 Status */
+#define BITM_INTC_INTCFLAG1_FLAG9            0x00000200    /*  Custom IRQ 0 Status */
+#define BITM_INTC_INTCFLAG1_FLAG8            0x00000100    /*  Variance IRQ status. */
+#define BITM_INTC_INTCFLAG1_FLAG7            0x00000080
+#define BITM_INTC_INTCFLAG1_FLAG6            0x00000040
+#define BITM_INTC_INTCFLAG1_FLAG5            0x00000020
+#define BITM_INTC_INTCFLAG1_FLAG4            0x00000010
+#define BITM_INTC_INTCFLAG1_FLAG3            0x00000008
+#define BITM_INTC_INTCFLAG1_FLAG2            0x00000004
+#define BITM_INTC_INTCFLAG1_FLAG1            0x00000002
+#define BITM_INTC_INTCFLAG1_FLAG0            0x00000001
+/** 
+ * @} AD5940RegistersBitfields
+ * @endcond
+ * */
+
+/**
+ * @addtogroup SPI_Block
+ * @{
+ *    @defgroup SPI_Block_Const
+ *    @{
+ * 
+*/
+#define SPICMD_SETADDR    0x20      /**< set the register address that is going to operate. */
+#define SPICMD_READREG    0x6d      /**< command to read register */
+#define SPICMD_WRITEREG   0x2d      /**< command to write register */
+#define SPICMD_READFIFO   0x5f      /**< command to read FIFO */
+/**
+ * @} SPI_Block_Const
+ * @} SPI_Block
+*/
+
+/** 
+ * @addtogroup AFE_Control
+ * @{
+ * */
+
+/** 
+ * @defgroup AFE_Control_Const
+ * @{
+ * */
+
+/** 
+ * @defgroup AFEINTC_Const
+ * @brief AD5940 has two interrupt controller INTC0 and INTC1. Both of them have ability to generate interrupt signal from GPIO.
+ * @{
+ * */
+/* AFE Interrupt controller selection */
+#define AFEINTC_0                   0   /**< Interrupt controller 0 */     
+#define AFEINTC_1                   1   /**< Interrupt controller 1 */
+/** @} */
+
+/** 
+ * @defgroup AFEINTC_SRC_Const
+ * @brief Interrupt source selection. These sources are defined as bit mask. They are available for register INTCCLR, INTCSEL0/1, INTCFLAG0/1
+ * @{
+ * */
+#define AFEINTSRC_ADCRDY            0x00000001  /**<  Bit0, ADC Result Ready Status */
+#define AFEINTSRC_DFTRDY            0x00000002  /**<  Bit1, DFT Result Ready Status */
+#define AFEINTSRC_SINC2RDY          0x00000004  /**<  Bit2, SINC2/Low Pass Filter Result Status */
+#define AFEINTSRC_TEMPRDY           0x00000008  /**<  Bit3, Temp Sensor Result Ready */
+#define AFEINTSRC_ADCMINERR         0x00000010	/**<  Bit4, ADC Minimum Value */
+#define AFEINTSRC_ADCMAXERR         0x00000020	/**<  Bit5, ADC Maximum Value */
+#define AFEINTSRC_ADCDIFFERR        0x00000040  /**<  Bit6, ADC Delta Ready */
+#define AFEINTSRC_MEANRDY           0x00000080	/**<  Bit7, Mean Result Ready */
+#define AFEINTSRC_VARRDY            0x00000100	/**<  Bit8, Variance Result Ready */
+#define AFEINTSRC_CUSTOMINT0        0x00000200  /**<  Bit9,  Custom interrupt source 0. It happens when **sequencer** writes 1 to register AFEGENINTSTA.BIT0 */
+#define AFEINTSRC_CUSTOMINT1        0x00000400  /**<  Bit10, Custom interrupt source 1. It happens when **sequencer** writes 1 to register AFEGENINTSTA.BIT1*/
+#define AFEINTSRC_CUSTOMINT2        0x00000800  /**<  Bit11, Custom interrupt source 2. It happens when **sequencer** writes 1 to register AFEGENINTSTA.BIT2 */
+#define AFEINTSRC_CUSTOMINT3        0x00001000  /**<  Bit12, Custom interrupt source 3. It happens when **sequencer** writes 1 to register AFEGENINTSTA.BIT3 */
+#define AFEINTSRC_BOOTLDDONE        0x00002000  /**<  Bit13, OTP Boot Loading Done */
+#define AFEINTSRC_WAKEUP            0x00004000  /**<  Bit14, AFE Woken up*/
+#define AFEINTSRC_ENDSEQ    	      0x00008000  /**<  Bit15, End of Sequence Interrupt. */
+#define AFEINTSRC_SEQTIMEOUT   	    0x00010000  /**<  Bit16, Sequencer Timeout Command Finished. */
+#define AFEINTSRC_SEQTIMEOUTERR     0x00020000  /**<  Bit17, Sequencer Timeout Command Error. */
+#define AFEINTSRC_CMDFIFOFULL       0x00040000  /**<  Bit18, Command FIFO Full Interrupt. */
+#define AFEINTSRC_CMDFIFOEMPTY      0x00080000  /**<  Bit19, Command FIFO Empty */
+#define AFEINTSRC_CMDFIFOTHRESH     0x00100000  /**<  Bit20, Command FIFO Threshold Interrupt. */
+#define AFEINTSRC_CMDFIFOOF         0x00200000  /**<  Bit21, Command FIFO Overflow Interrupt. */
+#define AFEINTSRC_CMDFIFOUF         0x00400000  /**<  Bit22, Command FIFO Underflow Interrupt. */
+#define AFEINTSRC_DATAFIFOFULL      0x00800000  /**<  Bit23, Data FIFO Full Interrupt. */
+#define AFEINTSRC_DATAFIFOEMPTY     0x01000000  /**<  Bit24, Data FIFO Empty */
+#define AFEINTSRC_DATAFIFOTHRESH    0x02000000  /**<  Bit25, Data FIFO Threshold Interrupt. */
+#define AFEINTSRC_DATAFIFOOF        0x04000000  /**<  Bit26, Data FIFO Overflow Interrupt. */
+#define AFEINTSRC_DATAFIFOUF        0x08000000  /**<  Bit27, Data FIFO Underflow Interrupt. */
+#define AFEINTSRC_WDTIRQ            0x10000000  /**<  Bit28, WDT Timeout Interrupt. */
+#define AFEINTSRC_CRC_OUTLIER       0x20000000  /**<  Bit29, CRC interrupt for M355, Outlier Int for AD5940  */
+#define AFEINTSRC_GPT0INT_SLPWUT    0x40000000  /**<  Bit30, Gneral Pupose Timer0 IRQ for M355. Sleep or Wakeup Tiemr timeout for AD5940*/
+#define AFEINTSRC_GPT1INT_TRYBRK    0x80000000  /**<  Bit31, Gneral Pupose Timer1 IRQ for M355. Tried to Break IRQ for AD5940*/
+#define AFEINTSRC_ALLINT            0xffffffff  /**<  mask of all interrupt */
+/** @} */
+
+/**
+ * @defgroup AFEPWR_Const
+ * @brief AFE power mode. 
+ * @details It will set the whole analog system power mode include HSDAC, Excitation Buffer, HSTIA, ADC front-buffer etc.
+ * @{
+*/
+#define AFEPWR_LP                   0   /**< Set AFE to Low Power mode. For signal <80kHz, use it. */
+#define AFEPWR_HP                   1   /**< Set AFE to High Power mode. For signal >80kHz, use it. */
+/**
+ * @}
+*/
+
+/**
+ * @defgroup AFEBW_Const
+ * @brief AFE system bandwidth. 
+ * @details It will set the whole analog bandwidth include HSDAC, Excitation Buffer, HSTIA, ADC front-buffer etc.
+ * @{
+*/
+#define AFEBW_AUTOSET               0   /**< Set the bandwidth automatically based on WGFCW frequency word. */
+#define AFEBW_50KHZ                 1   /**< 50kHZ system bandwidth(DAC/ADC) */
+#define AFEBW_100KHZ                2   /**< 100kHZ system bandwidth(DAC/ADC) */
+#define AFEBW_250KHZ                3   /**< 250kHZ system bandwidth(DAC/ADC) */
+/**
+ * @}
+*/
+
+/**
+ * @defgroup AFECTRL_Const
+ * @brief AFE Control signal set. Bit masks for register AFECON.
+ * @details This is all the available control signal for function @ref AD5940_AFECtrlS
+ * @warning Bit field in register AFECON has some opposite meaning as below definitions. We use all positive word here
+ *          like HPREF instead of HPREFDIS. This set is only used in function @ref AD5940_AFECtrlS, the second parameter
+ *          decides whether enable it or disable it. 
+ * @{
+*/
+#define AFECTRL_HPREFPWR            (1L<<5)    /**< High power reference on-off control */
+#define AFECTRL_HSDACPWR            (1L<<6)    /**< High speed DAC on-off control */
+#define AFECTRL_ADCPWR              (1L<<7)    /**< ADC power on-off control */
+#define AFECTRL_ADCCNV              (1L<<8)    /**< Start ADC convert enable */
+#define AFECTRL_EXTBUFPWR           (1L<<9)    /**< Excitation buffer power control */
+#define AFECTRL_INAMPPWR            (1L<<10)   /**< Excitation loop input amplifier before P/N node power control */
+#define AFECTRL_HSTIAPWR            (1L<<11)   /**< High speed TIA amplifier power control */   
+#define AFECTRL_TEMPSPWR            (1L<<12)   /**< Temperature sensor power */
+#define AFECTRL_TEMPCNV             (1L<<13)   /**< Start Temperature sensor convert */
+#define AFECTRL_WG                  (1L<<14)   /**< Waveform generator on-off control */
+#define AFECTRL_DFT                 (1L<<15)   /**< DFT engine on-off control */
+#define AFECTRL_SINC2NOTCH          (1L<<16)	  /**< SIN2+Notch block on-off control */
+#define AFECTRL_ALDOLIMIT           (1L<<19)	  /**< ALDO current limit on-off control */
+#define AFECTRL_DACREFPWR           (1L<<20)	  /**< DAC reference buffer power control */ 
+#define AFECTRL_DCBUFPWR            (1L<<21)	  /**< Excitation loop DC offset buffer sourced from LPDAC power control */           
+#define AFECTRL_ALL                 0x39ffe0   /**< All control signals */           
+/**
+ * @}
+*/
+
+/**
+ * @defgroup LPMODECTRL_Const
+ * @brief   LP Control signal(bit mask) for register LPMODECON
+ * @details  This is all the available control signal for function @ref AD5940_LPModeCtrlS
+ * @warning Bit field in register LPMODECON has some opposite meaning as below definitions. We use all positive word here
+ *          like HPREFPWR instead of HPREFDIS. This set is only used in function @ref AD5940_AFECtrlS, the second parameter
+ *          decides whether enable or disable selected block(s). 
+ * @{
+*/
+#define LPMODECTRL_HFOSCEN             (1<<0)  /**< Enable internal HFOSC. Note: the register defination is set this bit to 1 to disable it. */
+#define LPMODECTRL_HPREFPWR            (1<<1)  /**< High power reference power EN. Note: the register defination is set this bit to 1 to disable it. */
+#define LPMODECTRL_ADCCNV              (1<<2)  /**< Start ADC convert enable */
+#define LPMODECTRL_REPEATEN            (1<<3)  /**< Enable repeat convert function. This will enable ADC power automatically */
+#define LPMODECTRL_GLBBIASZ            (1<<4)  /**< Enable Global ZTAT bias. Disable it to save more power */
+#define LPMODECTRL_GLBBIASP            (1<<5)  /**< Enable Global PTAT bias. Disable it to save more power */
+#define LPMODECTRL_BUFHP1P8V           (1<<6)  /**< High power 1.8V reference buffer */
+#define LPMODECTRL_BUFHP1P1V           (1<<7)  /**< High power 1.1V reference buffer */
+#define LPMODECTRL_ALDOPWR             (1<<8)  /**< Enable ALDO. Note: register defination is set this bit to 1 to disable ALDO. */
+#define LPMODECTRL_ALL                 0x1ff   /**< All Control signal Or'ed together*/
+#define LPMODECTRL_NONE                0       /**< No blocks selected */
+/** @} */
+
+/**
+ * @defgroup AFERESULT_Const
+ * @brief The available AFE results type. Used for function @ref AD5940_ReadAfeResult
+ * @{
+*/
+#define AFERESULT_SINC3             0 /**< SINC3 result */
+#define AFERESULT_SINC2             1 /**< SINC2+NOTCH result */
+#define AFERESULT_TEMPSENSOR        2 /**< Temperature sensor result */
+#define AFERESULT_DFTREAL           3 /**< DFT Real result */
+#define AFERESULT_DFTIMAGE          4 /**< DFT Imaginary result */
+#define AFERESULT_STATSMEAN         5 /**< Statistic Mean result */
+#define AFERESULT_STATSVAR          6 /**< Statistic Variance result */
+/** @} */
+
+/** 
+ * @} AFE_Control_Const
+ * @} AFE_Control
+ * */
+
+/**
+ * @addtogroup High_Speed_Loop
+ * @{
+ *    @defgroup High_Speed_Loop_Const
+ *    @{
+*/
+
+/**
+ * @defgroup Switch_Matrix_Block_Const
+ * @{
+ *    @defgroup SWD_Const
+ *    @brief Switch D set. This is bit mask for register DSWFULLCON. 
+ *    @details
+ *        It's used to initialize structure @ref SWMatrixCfg_Type 
+ *        The bit masks can be OR'ed together. For example 
+ *          - `SWD_AIN1|SWD_RCAL0` means close SWD_AIN1 and SWD_RCAL0 in same time, and open all other D switches.
+ *          - `SWD_AIN2` means close SWD_AIN2 and open all other D switches.
+ *    @{
+*/
+#define SWD_OPEN                    (0<<0)    /**< Open all D switch. */
+#define SWD_RCAL0                   (1<<0)    /**< pin RCAL0 */
+#define SWD_AIN1                    (1<<1)    /**< Pin AIN1 */
+#define SWD_AIN2                    (1<<2)    /**< Pin AIN2 */
+#define SWD_AIN3                    (1<<3)    /**< Pin AIN3 */
+#define SWD_CE0                     (1<<4)    /**< Pin CE0 */
+#define SWD_CE1                     (1<<5)    /**< CE1 in ADuCM355 */
+#define SWD_AFE1                    (1<<5)    /**< AFE1 in AD594x */
+#define SWD_SE0                     (1<<6)    /**< Pin SE0 */
+#define SWD_SE1                     (1<<7)    /**< SE1 in ADuCM355 */
+#define SWD_AFE3                    (1<<7)    /**< AFE3 in AD594x */
+/** @} */
+
+/**
+ * @defgroup SWP_Const
+ * @brief Switch P set. This is bit mask for register PSWFULLCON.
+ * @details
+ *        It's used to initialize structure @ref SWMatrixCfg_Type.
+ *        The bit masks can be OR'ed together. For example 
+ *          - `SWP_RCAL0|SWP_AIN1` means close SWP_RCAL0 and SWP_AIN1 in same time, and open all other P switches.
+ *          - `SWP_SE0` means close SWP_SE0 and open all other P switches.
+ * @{
+*/
+#define SWP_OPEN                    0         /**< Open all P switches */
+#define SWP_RCAL0                   (1<<0)    /**< Pin RCAL0 */
+#define SWP_AIN1                    (1<<1)    /**< Pin AIN1 */
+#define SWP_AIN2                    (1<<2)    /**< Pin AIN2 */
+#define SWP_AIN3                    (1<<3)    /**< Pin AIN3 */
+#define SWP_RE0                     (1<<4)    /**< Pin RE0 */
+#define SWP_RE1                     (1<<5)    /**< RE1 in ADuCM355 */
+#define SWP_AFE2                    (1<<5)    /**< AFE2 in AD5940 */
+#define SWP_SE0                     (1<<6)    /**< Pin SE0 */
+#define SWP_DE0                     (1<<7)    /**< Pin DE0 */
+#define SWP_SE1                     (1<<8)    /**< SE1 in ADuCM355 */
+#define SWP_AFE3                    (1<<8)    /**< AFE3 in AD5940 */
+#define SWP_DE1                     (1<<9)    /**< ADuCM355 Only. */
+#define SWP_CE0                     (1<<10)   /**< Pin CE0 */
+#define SWP_CE1                     (1<<11)   /**< CE1 in ADuCM355 */
+#define SWP_AFE1                    (1<<11)   /**< AFE1 in AD5940 */
+#define SWP_PL                      (1<<13)   /**< Internal PL switch */
+#define SWP_PL2                     (1<<14)   /**< Internal PL2 switch */
+/** @} */
+
+/**
+ * @defgroup SWN_Const
+ * @brief Switch N set. This is bit mask for register NSWFULLCON.
+ * @details
+ *        It's used to initialize structure @ref SWMatrixCfg_Type.
+ *        The bit masks can be OR'ed together. For example 
+ *          - `SWN_RCAL0|SWN_AIN1` means close SWN_RCAL0 and SWN_AIN1 in same time, and open all other N switches.
+ *          - `SWN_SE0` means close SWN_SE0 and open all other N switches.
+ * @{
+*/
+#define SWN_OPEN                    0       /**< Open all N switches */
+#define SWN_RCAL1                   (1<<9)  /**< Pin RCAL1 */
+#define SWN_AIN0                    (1<<0)  /**< Pin AIN0 */
+#define SWN_AIN1                    (1<<1)  /**< Pin AIN1 */
+#define SWN_AIN2                    (1<<2)  /**< Pin AIN2 */
+#define SWN_AIN3                    (1<<3)  /**< Pin AIN3  */
+#define SWN_SE0LOAD                 (1<<4)  /**< SE0_LOAD is different from PIN SE0. It's the point after 100Ohm load resistor */
+#define SWN_DE0LOAD                 (1<<5)  /**< DE0_Load is after Rload resistor */
+#define SWN_SE1LOAD                 (1<<6)  /**< SE1_LOAD in ADuCM355 */
+#define SWN_AFE3LOAD                (1<<6)  /**< AFE3LOAD in ADuCM355 */
+#define SWN_DE1LOAD                 (1<<7)  /**< ADuCM355 Only*/
+#define SWN_SE0                     (1<<8)  /**< SE0 here means the PIN SE0. */
+#define SWN_NL                      (1<<10) /**< Internal NL switch */
+#define SWN_NL2                     (1<<11) /**< Internal NL2 switch */
+/** @} */
+
+/**
+ * @defgroup SWT_Const
+ * @brief Switch T set. This is bit mask for register TSWFULLCON.
+ * @details
+ *        It's used to initialize structure @ref SWMatrixCfg_Type.
+ *        The bit masks can be OR'ed together. For example 
+ *          - SWT_RCAL0|SWT_AIN1 means close SWT_RCAL0 and SWT_AIN1 in same time, and open all other T switches.
+ *          - SWT_SE0LOAD means close SWT_SE0LOAD and open all other T switches.
+ * @{
+*/
+#define SWT_OPEN                    0         /**< Open all T switches */
+#define SWT_RCAL1                   (1<<11)   /**< Pin RCAL1 */
+#define SWT_AIN0                    (1<<0)    /**< Pin AIN0 */
+#define SWT_AIN1                    (1<<1)    /**< Pin AIN1 */
+#define SWT_AIN2                    (1<<2)    /**< Pin AIN2 */
+#define SWT_AIN3                    (1<<3)    /**< Pin AIN3 */
+#define SWT_SE0LOAD                 (1<<4)    /**< SE0_LOAD is different from PIN SE0. It's the point after 100Ohm load resistor */
+#define SWT_DE0                     (1<<5)    /**< DE0 pin. */
+#define SWT_SE1LOAD                 (1<<6)    /**< SE1_LOAD on ADuCM355*/
+#define SWT_AFE3LOAD                (1<<6)    /**< AFE3_LOAD on ADuCM355*/
+#define SWT_DE1                     (1<<7)    /**< ADuCM355 Only*/
+#define SWT_TRTIA                   (1<<8)    /**< T9 switch. Connect RTIA to T matrix */
+#define SWT_DE0LOAD                 (1<<9)    /**< DE0Load is the position after Rload Resisor */
+#define SWT_DE1LOAD                 (1<<10)   /**< DE1Load is the position after Rload Resisor */
+/** @} */
+
+/** @} Switch_Matrix_Block_Const */
+
+
+/**
+ * @defgroup Waveform_Generator_Block_Const
+ * @{
+*/
+/**
+ * @defgroup WGTYPE_Const
+ * @brief Waveform generator signal type
+ * @{
+*/
+#define WGTYPE_MMR                  0 /**< Direct write to DAC using register */
+#define WGTYPE_SIN                  2 /**< Sine wave generator */
+#define WGTYPE_TRAPZ                3 /**< Trapezoid generator */
+/** @} */
+/** @} Waveform_Generator_Block_Const */
+
+/**
+ * @defgroup HSDAC_Block_Const
+ * @{
+*/
+/* Excitation buffer gain selection */
+/**
+ * @defgroup EXCITBUFGAIN_Const
+ * @{
+*/
+#define EXCITBUFGAIN_2              0   /**< Excitation buffer gain is x2 */
+#define EXCITBUFGAIN_0P25           1   /**< Excitation buffer gain is x1/4 */
+/** @} */
+
+/**
+ * @defgroup HSDACGAIN_Const
+ * @{
+*/
+/* HSDAC PGA Gain selection(DACCON.BIT0) */
+#define HSDACGAIN_1                 0   /**< Gain is x1 */
+#define HSDACGAIN_0P2               1   /**< Gain is x1/5 */
+/** @} */
+/** @} */ //HSDAC_Block_Const
+
+/**
+ * @defgroup HSTIA_Block_Const
+ * @{
+ * */
+/* HSTIA Amplifier Positive Input selection */
+
+/**
+ * @defgroup HSTIABIAS_Const
+ * @warning When select Vzero0 as bias, close LPDAC switch<xxx>
+ * @{
+*/
+#define HSTIABIAS_1P1               0   /**< Internal 1.1V common voltage from internal 1.1V reference buffer */
+#define HSTIABIAS_VZERO0            1   /**< From LPDAC0 Vzero0 output */
+#define HSTIABIAS_VZERO1            2   /**< From LPDAC1 Vzero1 output. Only available on ADuCM355. */
+/** @} */
+
+
+/* HSTIA Internal RTIA selection */
+
+/**
+ * @defgroup HSTIARTIA_Const
+ * @{
+*/
+#define HSTIARTIA_200               0     /**< HSTIA Internal RTIA resistor 200  */
+#define HSTIARTIA_1K                1     /**< HSTIA Internal RTIA resistor 1K   */
+#define HSTIARTIA_5K                2     /**< HSTIA Internal RTIA resistor 5K   */
+#define HSTIARTIA_10K               3     /**< HSTIA Internal RTIA resistor 10K  */
+#define HSTIARTIA_20K               4     /**< HSTIA Internal RTIA resistor 20K  */
+#define HSTIARTIA_40K               5     /**< HSTIA Internal RTIA resistor 40K  */
+#define HSTIARTIA_80K               6     /**< HSTIA Internal RTIA resistor 80K  */
+#define HSTIARTIA_160K              7     /**< HSTIA Internal RTIA resistor 160K */
+#define HSTIARTIA_OPEN              8     /**< Open internal resistor */
+/** @} */
+
+/**
+ * @defgroup HSTIADERTIA_Const
+ * @{
+*/
+#define HSTIADERTIA_50              0     /**< 50Ohm Settings depends on RLOAD resistor. */
+#define HSTIADERTIA_100             1     /**< 100Ohm Settings depends on RLOAD resistor.*/
+#define HSTIADERTIA_200             2     /**< 200Ohm Settings depends on RLOAD resistor.*/
+#define HSTIADERTIA_1K              3     /**< set bit[7:3] to 0x0b(11) */
+#define HSTIADERTIA_5K              4     /**< set bit[7:3] to 0x0c(12) */
+#define HSTIADERTIA_10K             5     /**< set bit[7:3] to 0x0d(13) */
+#define HSTIADERTIA_20K             6     /**< set bit[7:3] to 0x0e(14) */
+#define HSTIADERTIA_40K             7     /**< set bit[7:3] to 0x0f(15) */
+#define HSTIADERTIA_80K             8     /**< set bit[7:3] to 0x10(16) */
+#define HSTIADERTIA_160K            9     /**< set bit[7:3] to 0x11(17) */
+#define HSTIADERTIA_TODE            10    /**< short HSTIA output to DE0 pin. set bit[7:3] to 0x12(18) */
+#define HSTIADERTIA_OPEN            11    /**< Default state is set to OPEN RTIA by setting bit[7:3] to 0x1f */      
+/** @} */
+
+/* HSTIA DE0 Terminal internal RLOAD selection */
+/**
+ * @defgroup HSTIADERLOAD_Const
+ * @{
+*/
+#define HSTIADERLOAD_0R             0     /**< set bit[2:0] to 0x00 */
+#define HSTIADERLOAD_10R            1     /**< set bit[2:0] to 0x01 */
+#define HSTIADERLOAD_30R            2     /**< set bit[2:0] to 0x02 */
+#define HSTIADERLOAD_50R            3     /**< set bit[2:0] to 0x03 */
+#define HSTIADERLOAD_100R           4     /**< set bit[2:0] to 0x04 */
+#define HSTIADERLOAD_OPEN           5     /**< RLOAD open means open switch between HSTIA negative input and Rload resistor(<S1>).Default state is OPEN RLOAD by setting HSTIARES03CON[2:0] to 0x5, 0x6 or 0x7 */
+/** @} */
+
+/**
+ * @defgroup HSTIAPWRMOE_Const
+ * @{
+*/
+#define HSTIAPWRMOE_LP              0     /**< HSTIA in LP mode */
+#define HSTIAPWRMOE_HP              1     /**< HSTIA in HP mode */
+/** @} */
+
+
+/** @} HSTIA_Block_Const */
+/**
+ * @} High_Speed_Loop_Const
+ * @} High_Speed_Loop
+*/
+
+/**
+ * @addtogroup Low_Power_Loop
+ * Low power includes low power DAC and two low power amplifiers(PA and TIA)
+ * @{
+ *    @defgroup Low_Power_Loop_Const
+ *              The constant used in Low power loop.
+ *    @{
+*/
+
+/**
+ * @defgroup LPDAC_Block_Const
+ * @{
+ * */
+/**
+ * @defgroup LPDAC_Const
+ * Select which LPDAC is accessing.
+ * @note This parameter must be configured correctly
+ * @{
+*/
+#define LPDAC0                      0   /**< LPDAC0 */
+#define LPDAC1                      1   /**< LPDAC1, ADuCM355 Only */
+/** @} */
+/**
+ * @defgroup LPDACSRC_Const
+ * LPDAC data source selection. Either from MMR or from waveform generator.
+ * @{
+*/
+#define LPDACSRC_MMR                0   /**< Get data from register REG_AFE_LPDACDAT0DATA0 */
+#define LPDACSRC_WG                 1   /**< Get data from waveform generator */
+/** @} */
+
+/**
+ * @defgroup LPDACSW_Const
+ * @brief LPDAC switch settings
+ * @{
+*/
+#define LPDACSW_VBIAS2LPPA        0x10  /**< switch between LPDAC Vbias output and LPPA(low power PA(Potential Amplifier)) */
+#define LPDACSW_VBIAS2PIN         0x08  /**< Switch between LPDAC Vbias output and Vbias pin */
+#define LPDACSW_VZERO2LPTIA       0x04  /**< Switch between LPDAC Vzero output and LPTIA positive input */
+#define LPDACSW_VZERO2PIN         0x02  /**< Switch between LPDAC Vzero output and Vzero pin */
+#define LPDACSW_VZERO2HSTIA       0x01  /**< Switch between LPDAC Vzero output and HSTIA positive input MUX */
+/** @} */
+
+/**
+ * @defgroup LPDACVZERO_Const
+ * @brief Vzero MUX selection
+ * @{
+*/
+#define LPDACVZERO_6BIT             0   /**< Connect Vzero to 6bit LPDAC output */
+#define LPDACVZERO_12BIT            1   /**< Connect Vzero to 12bit LPDAC output */
+/** @} */
+
+/**
+ * @defgroup LPDACVBIAS_Const
+ * @brief Vbias MUX selection
+ * @{
+*/
+#define LPDACVBIAS_6BIT             1   /**< Connect Vbias to 6bit LPDAC output */
+#define LPDACVBIAS_12BIT            0   /**< Connect Vbias to 12bit LPDAC output */
+/** @} */
+
+
+/**
+ * @defgroup LPDACREF_Const
+ * @brief LPDAC reference selection
+ * @{
+*/
+#define LPDACREF_2P5                0   /**< Internal 2.5V reference */
+#define LPDACREF_AVDD               1   /**< Use AVDD as reference */
+/** @} */
+
+/** @} */ //LPDAC_Block_Const
+
+/**
+ * @defgroup LPAMP_Block_Const
+ * @brief Low power amplifies include potential-state amplifier(PA in short) and TIA.
+ * @{
+ * */
+
+/**
+ * @defgroup LPTIA_Const
+ * @brief LPTIA selecion
+ * @{
+ * */
+#define LPTIA0                      0   /**< LPTIA0 */
+#define LPTIA1                      1   /**< LPTIA1, ADuCM355 Only */
+/** @} */
+
+/**
+ * @defgroup LPTIARF_Const
+ * @brief LPTIA LPF Resistor selection
+ * @{
+ * */
+#define LPTIARF_OPEN                0   /**< Disconnect Rf resistor */
+#define LPTIARF_SHORT               1   /**< Bypass Rf resistor */
+#define LPTIARF_20K                 2   /**< 20kOhm Rf */
+#define LPTIARF_100K                3   /**< Rf resistor 100kOhm */
+#define LPTIARF_200K                4   /**< Rf resistor 200kOhm */
+#define LPTIARF_400K                5   /**< Rf resistor 400kOhm */
+#define LPTIARF_600K                6   /**< Rf resistor 600kOhm */
+#define LPTIARF_1M                  7   /**< Rf resistor 1MOhm */
+/** @} */
+
+/**
+ * @defgroup LPTIARLOAD_Const
+ * @brief LPTIA Rload Selection
+ * @{
+*/
+#define LPTIARLOAD_SHORT            0   /**< 0Ohm Rload */
+#define LPTIARLOAD_10R              1   /**< 10Ohm Rload */
+#define LPTIARLOAD_30R              2   /**< Rload resistor 30Ohm */
+#define LPTIARLOAD_50R              3   /**< Rload resistor 50Ohm */
+#define LPTIARLOAD_100R             4   /**< Rload resistor 100Ohm */
+#define LPTIARLOAD_1K6              5   /**< Only available when RTIA setting >= 2KOHM */
+#define LPTIARLOAD_3K1              6   /**< Only available when RTIA setting >= 4KOHM */
+#define LPTIARLOAD_3K6              7   /**< Only available when RTIA setting >= 4KOHM */
+/** @} */
+
+/**
+ * @defgroup LPTIARTIA_Const
+ * @brief LPTIA RTIA Selection
+ * @note The real RTIA resistor value dependents on Rload settings.
+ * @{
+*/
+#define LPTIARTIA_OPEN              0   /**< Disconnect LPTIA Internal RTIA */
+#define LPTIARTIA_200R              1   /**< 200Ohm Internal RTIA */
+#define LPTIARTIA_1K                2   /**< 1KOHM */
+#define LPTIARTIA_2K                3   /**< 2KOHM */
+#define LPTIARTIA_3K                4   /**< 3KOHM */
+#define LPTIARTIA_4K                5   /**< 4KOHM */
+#define LPTIARTIA_6K                6   /**< 6KOHM */
+#define LPTIARTIA_8K                7   /**< 8KOHM */
+#define LPTIARTIA_10K               8   /**< 10KOHM */
+#define LPTIARTIA_12K               9   /**< 12KOHM */
+#define LPTIARTIA_16K               10  /**< 16KOHM */
+#define LPTIARTIA_20K               11  /**< 20KOHM */
+#define LPTIARTIA_24K               12  /**< 24KOHM */
+#define LPTIARTIA_30K               13  /**< 30KOHM */
+#define LPTIARTIA_32K               14  /**< 32KOHM */
+#define LPTIARTIA_40K               15  /**< 40KOHM */
+#define LPTIARTIA_48K               16  /**< 48KOHM */
+#define LPTIARTIA_64K               17  /**< 64KOHM */
+#define LPTIARTIA_85K               18  /**< 85KOHM */
+#define LPTIARTIA_96K               19  /**< 96KOHM */
+#define LPTIARTIA_100K              20  /**< 100KOHM */
+#define LPTIARTIA_120K              21  /**< 120KOHM */
+#define LPTIARTIA_128K              22  /**< 128KOHM */
+#define LPTIARTIA_160K              23  /**< 160KOHM */
+#define LPTIARTIA_196K              24  /**< 196KOHM */
+#define LPTIARTIA_256K              25  /**< 256KOHM */
+#define LPTIARTIA_512K              26  /**< 512KOHM */
+/** @} */
+
+/**
+ * @defgroup LPAMP_Const
+ * LPAMP selecion. On AD594x, only LPAMP0 is available. 
+ * @note This parameter must be configured correctly.
+ * @{
+ * */
+#define LPAMP0                      0   /**< LPAMP0, AMP include both LPTIA and Potentio-stat amplifiers */
+#define LPAMP1                      1   /**< LPAMP1, ADuCM355 Only */
+/** @} */
+
+/**
+ * @defgroup LPAMPPWR_Const
+ * @brief Low power amplifier(PA and TIA) power mode selection.
+ * @{
+*/
+#define LPAMPPWR_NORM               0   /**< Normal Power mode */
+#define LPAMPPWR_BOOST1             1   /**< Boost power to level 1 */
+#define LPAMPPWR_BOOST2             2   /**< Boost power to level 2 */
+#define LPAMPPWR_BOOST3             3   /**< Boost power to level 3 */
+#define LPAMPPWR_HALF               4   /**< Put PA and TIA in half power mode */
+/** @} */
+
+#define LPTIASW(n)                  (1L<<n) /**< LPTIA switch control. Use this macro to set LpTiaSW field of @ref LPAmpCfg_Type  */
+
+/** 
+ * @} LPAMP_Block_Const
+ * @} Low_Power_Loop_Const
+ * @} Low_Power_Loop
+ * 
+ * */
+
+/** 
+ * @addtogroup DSP_Block
+ * DSP block include signal chain from raw ADC data to various filters, DFT engine and Statistic Functions etc.
+ * @{
+ *    @defgroup DSP_Block_Const
+ *    @{
+ *        @defgroup ADC_Block_Const
+ *        @{
+ */
+
+/**
+ * @defgroup ADCPGA_Const
+ * @brief ADC PGA Selection
+ * @note Only gain 1.5 is factory calibrated.
+ * @{
+*/
+#define ADCPGA_1                    0     /**< ADC PGA Gain of 1 */
+#define ADCPGA_1P5                  1     /**< ADC PGA Gain of 1.5 */
+#define ADCPGA_2                    2     /**< ADC PGA Gain of 2 */
+#define ADCPGA_4                    3     /**< ADC PGA Gain of 4 */
+#define ADCPGA_9                    4     /**< ADC PGA Gain of 9 */
+#define IS_ADCPGA(pga)              (((pga) == ADCPGA_1) ||\
+                                    (pga) == ADCPGA_1P5) ||\
+                                    (pga) == ADCPGA_2) ||\
+                                    (pga) == ADCPGA_4) ||\
+                                    (pga) == ADCPGA_9))
+/** 
+ * @} 
+ * */
+
+/**
+ * @defgroup ADCMUXP_Const
+ * @brief ADC Channel P Configuration
+ * @{
+*/
+#define ADCMUXP_FLOAT               0x0     /**< float */
+#define ADCMUXP_HSTIA_P             0x1     /**< output of HSTIA */
+#define ADCMUXP_AIN0                0x4     /**< pin AIN0 */
+#define ADCMUXP_AIN1                0x5     /**< pin AIN1 */
+#define ADCMUXP_AIN2                0x6     /**< pin AIN2 */
+#define ADCMUXP_AIN3                0x7     /**< pin AIN3 */
+#define ADCMUXP_AVDD_2              0x8     /**< AVDD/2  */
+#define ADCMUXP_DVDD_2              0x9     /**< DVDD/2  */
+#define ADCMUXP_AVDDREG             0xA     /**< AVDD internal regulator output. It's around 1.8V */
+#define ADCMUXP_TEMPP               0xB     /**< Internal temperature output postive terminal */
+#define ADCMUXP_VSET1P1             0xC     /**< Internal 1.1V bias voltage */
+#define ADCMUXP_VDE0                0xD     /**< Voltage of DE0 pin  */
+#define ADCMUXP_VSE0                0xE     /**< Voltage of SE0 pin  */
+#define ADCMUXP_VSE1                0xF     /**< Voltage of SE1 pin on ADuCM355  */
+#define ADCMUXP_VAFE3               0xF     /**< Voltage of AFE3 pin on AD5940. */
+#define ADCMUXP_VREF2P5             0x10    /**< 1.25V. The internal 2.5V reference buffer output divided by 2. */
+#define ADCMUXP_VREF1P8DAC          0x12    /**< HSDAC 1.8V internal reference. It's only available when both AFECON.BIT20 and AFECON.BIT6 are set. */
+#define ADCMUXP_TEMPN               0x13    /**< Internal temperature output negative terminal */
+#define ADCMUXP_AIN4                0x14    /**< Voltage of AIN4/LPF0 pin  */
+#define ADCMUXP_AIN5                0x15    /**< Voltage of AIN5 pin  */
+#define ADCMUXP_AIN6                0x16    /**< Voltage of AIN6 pin, not available on AD5941  */
+#define ADCMUXP_VZERO0              0x17    /**< Voltage of Vzero0 pin  */
+#define ADCMUXP_VBIAS0              0x18    /**< Voltage of Vbias0 pin  */
+#define ADCMUXP_VCE0                0x19    /**< Pin CE0 */
+#define ADCMUXP_VRE0                0x1A    /**< Pin RE0 */
+#define ADCMUXP_VZERO1              0x1B    /**< Voltage of Vzero1 pin on ADuCM355 */
+#define ADCMUXP_VAFE4               0x1B    /**< Voltage of AFE4 pin on AD5940. */
+#define ADCMUXP_VBIAS1              0x1C    /**< Voltage of Vbias1 pin  */
+#define ADCMUXP_VCE1                0x1D    /**< Voltage of CE1 pin on ADuCM355. */
+#define ADCMUXP_VAFE1               0x1D    /**< Voltage of AFE1 pin on AD5940. */
+#define ADCMUXP_VRE1                0x1E    /**< Voltage of RE1 pin on ADuCM355. */
+#define ADCMUXP_VAFE2               0x1E    /**< Voltage of AFE2 pin on AD5940. */
+#define ADCMUXP_VCE0_2              0x1F    /**< VCE0 divide by 2 */
+#define ADCMUXP_VCE1_2              0x20    /**< VCE1 divide by 2 */
+#define ADCMUXP_LPTIA0_P            0x21    /**< Output of LPTIA0 */
+#define ADCMUXP_LPTIA1_P            0x22    /**< Output of LPTIA1 */
+#define ADCMUXP_AGND                0x23    /**< Internal AGND node */
+#define ADCMUXP_P_NODE              0x24    /**< Buffered voltage of excitation buffer P node.  */
+#define ADCMUXP_IOVDD_2             0x27    /**< IOVDD/2  */
+/**@}*/
+
+/**
+ * @defgroup ADCMUXN_Const
+ * @brief ADC Channel N Configuration
+ * @{
+*/
+#define ADCMUXN_FLOAT               0x0      /**< float */
+#define ADCMUXN_HSTIA_N             0x1      /**< HSTIA negative input node. */
+#define ADCMUXN_LPTIA0_N            0x2      /**< LPTIA0 negative input node. */
+#define ADCMUXN_LPTIA1_N            0x3      /**< LPTIA1 negative input node. */
+#define ADCMUXN_AIN0                0x4      /**< Pin AIN0 */
+#define ADCMUXN_AIN1                0x5      /**< Pin AIN1 */
+#define ADCMUXN_AIN2                0x6      /**< Pin AIN2 */
+#define ADCMUXN_AIN3                0x7      /**< Pin AIN3 */
+#define ADCMUXN_VSET1P1             0x8      /**< Internal 1.11V reference */
+#define ADCMUXN_VREF1P1             0x8      /**< Internal 1.11V reference, same as ADCMUXN_VSET1P1 */
+#define ADCMUXN_TEMPN               0xB      /**< Temperature sensor output. */
+#define ADCMUXN_AIN4                0xC      /**< AIN4 */
+#define ADCMUXN_AIN5                0xD      /**< AIN5 */
+#define ADCMUXN_AIN6                0xE      /**< AIN6 */
+#define ADCMUXN_VZERO0              0x10     /**< pin Vzero0 */
+#define ADCMUXN_VBIAS0              0x11     /**< pin Vbias0 */
+#define ADCMUXN_VZERO1              0x12     /**< pin Vzero1 */
+#define ADCMUXN_AFE4                0x12     /**< Pin AFE4 on AD5940. */
+#define ADCMUXN_VBIAS1              0x13     /**< pin Vbias1 */
+#define ADCMUXN_N_NODE              0x14     /**< Buffered voltage of excitation buffer N node.  */
+/** @} */
+
+/**
+ * @defgroup ADCRATE_Const
+ * @brief ADC Current Sample Rate. If ADC clock is 32MHz, set it to ADCRATE_1P6MHZ. Otherwise, set it to ADCRATE_800KHZ.
+ * @{
+*/
+#define ADCRATE_800KHZ              1  /**< ADC input clock is 16MHz, sample rate is 800kHz */
+#define ADCRATE_1P6MHZ              0  /**< ADC input clock is 32MHz, sample rate is 1.6MHz */
+#define IS_ADCRATE(rate)            (((rate) == ADCRATE_800KHZ) ||\
+                                    (rate) == ADCRATE_1P6MHZ))
+/** @} */
+
+/**
+ * @defgroup ADCSINC3OSR_Const
+ * @brief ADC SINC3 Filter OSR. 2, 4 is recommended value. 5 is not recommended.
+ * @{
+*/
+#define ADCSINC3OSR_2               2     /**< ADC SINC3 OSR 2 */
+#define ADCSINC3OSR_4               1     /**< ADC SINC3 OSR 4 */
+#define ADCSINC3OSR_5               0     /**< ADC SINC3 OSR 5 */
+#define IS_ADCSINC3OSR(osr)        (((osr) == ADCSINC3OSR_2) ||\
+                                    (osr) == ADCSINC3OSR_4) ||\
+                                    (osr) == ADCSINC3OSR_5)) /**< checker of ADCSINC3OSR */
+/** @} */
+
+/**
+ * @defgroup ADCSINC2OSR_Const
+ * @brief ADC SINC2 Filter OSR.
+ * @{
+*/
+#define ADCSINC2OSR_22              0     /**< ADC SINC2 OSR 22   */
+#define ADCSINC2OSR_44              1     /**< ADC SINC2 OSR 44   */
+#define ADCSINC2OSR_89              2     /**< ADC SINC2 OSR 89   */
+#define ADCSINC2OSR_178             3     /**< ADC SINC2 OSR 178  */
+#define ADCSINC2OSR_267             4     /**< ADC SINC2 OSR 267  */
+#define ADCSINC2OSR_533             5     /**< ADC SINC2 OSR 533  */
+#define ADCSINC2OSR_640             6     /**< ADC SINC2 OSR 640  */
+#define ADCSINC2OSR_667             7     /**< ADC SINC2 OSR 667  */
+#define ADCSINC2OSR_800             8     /**< ADC SINC2 OSR 800  */
+#define ADCSINC2OSR_889             9     /**< ADC SINC2 OSR 889  */
+#define ADCSINC2OSR_1067            10    /**< ADC SINC2 OSR 1067 */
+#define ADCSINC2OSR_1333            11    /**< ADC SINC2 OSR 1333 */
+#define IS_ADCSINC2OSR(osr)        (((osr) == ADCSINC2OSR_22) ||\
+                                    (osr) == ADCSINC2OSR_44) ||\
+                                    (osr) == ADCSINC2OSR_89) ||\
+                                    (osr) == ADCSINC2OSR_178) ||\
+                                    (osr) == ADCSINC2OSR_267) ||\
+                                    (osr) == ADCSINC2OSR_533) ||\
+                                    (osr) == ADCSINC2OSR_640) ||\
+                                    (osr) == ADCSINC2OSR_667) ||\
+                                    (osr) == ADCSINC2OSR_800) ||\
+                                    (osr) == ADCSINC2OSR_889) ||\
+                                    (osr) == ADCSINC2OSR_1067) ||\
+                                    (osr) == ADCSINC2OSR_1333))   /**< checker of ADCSINC2OSR */
+/** @} */
+
+/**
+ * @defgroup ADCAVGNUM_Const
+ * @brief ADC Average filter for DFT. The average block locates after SINC3 filter. 
+ *        The output of average filter is directly feed into DFT block.
+ * @warning Once average filter is enabled, DFT source is automatically changed to averaged data.
+ * @{
+*/
+#define ADCAVGNUM_2                 0        /**< Take 2 input to do average. */
+#define ADCAVGNUM_4                 1        /**< Take 4 input to do average. */
+#define ADCAVGNUM_8                 2        /**< Take 8 input to do average. */
+#define ADCAVGNUM_16                3        /**< Take 16 input to do average. */
+#define IS_ADCAVGNUM(num)          (((num) == ADCAVGNUM_2) ||\
+                                    (num) == ADCAVGNUM_4) ||\
+                                    (num) == ADCAVGNUM_8) ||\
+                                    (num) == ADCAVGNUM_16)) /**< checker of ADCAVGNUM macro */
+/** @} */
+
+/** @} ADC_Block_Const */
+
+/**
+ * @defgroup DFT_Block_Const
+ * @{
+ * */
+
+/**
+ * @defgroup DFTSRC_Const
+ * @brief DFT source selection. When average function is enabled, DFT source automatically switch to average output.
+ * @{
+ * */
+#define DFTSRC_SINC2NOTCH           0   /**< SINC2+Notch filter block output. Bypass Notch to use SINC2 data */
+#define DFTSRC_SINC3                1   /**< SINC3 filter */
+#define DFTSRC_ADCRAW               2   /**< Raw ADC data */
+#define DFTSRC_AVG                  3   /**< Average output of SINC3. */
+/** @} */
+
+/**
+ * @defgroup DFTNUM_Const
+ * @brief DFT number selection.
+ * @{
+ * */
+#define DFTNUM_4                    0     /**< 4     Point */
+#define DFTNUM_8                    1     /**< 8     Point */
+#define DFTNUM_16                   2     /**< 16    Point */
+#define DFTNUM_32                   3     /**< 32    Point */
+#define DFTNUM_64                   4     /**< 64    Point */
+#define DFTNUM_128                  5     /**< 128   Point */
+#define DFTNUM_256                  6     /**< 256   Point */
+#define DFTNUM_512                  7     /**< 512   Point */
+#define DFTNUM_1024                 8     /**< 1024  Point */
+#define DFTNUM_2048                 9     /**< 2048  Point */
+#define DFTNUM_4096                 10    /**< 4096  Point */
+#define DFTNUM_8192                 11    /**< 8192  Point */
+#define DFTNUM_16384                12    /**< 16384 Point */
+/** @} */
+
+/** 
+ * @} DFT_Block_Const 
+*/
+
+/**
+ * @defgroup Statistic_Block_Const
+ * @{
+  */
+/**
+ * @defgroup STATSAMPLE_Const
+ * @brief The statistic module sample size. It decides how much data is used to do calculation.
+ * @{
+*/
+#define STATSAMPLE_128              0     /**< Sample size 128 */
+#define STATSAMPLE_64               1     /**< Sample size 64 */
+#define STATSAMPLE_32               2     /**< Sample size 32 */
+#define STATSAMPLE_16               3     /**< Sample size 16 */
+#define STATSAMPLE_8                4     /**< Sample size 8 */
+/** @} */
+
+/* Statistic standard deviation configure */
+/**
+ * @defgroup STATDEV_Const
+ * @brief The standard deviation configure
+ * @{
+*/
+#define STATDEV_1                   1     /**< Used for check outlier of ADC result */
+#define STATDEV_4                   4     /**< Used for check outlier of ADC result */
+#define STATDEV_9                   9     /**< Used for check outlier of ADC result */
+#define STATDEV_16                  16    /**< Used for check outlier of ADC result */
+#define STATDEV_25                  25    /**< Used for check outlier of ADC result */
+/** @} */
+
+/** 
+ * @} Statistic_Block_Const
+ * @} DSP_Block_Const
+ * @} DSP_Block
+ * 
+*/
+
+/**
+ * @addtogroup Sequencer_FIFO
+ * @{
+ *    @defgroup Sequencer_FIFO_Const
+ *    @brief This block includes sequencer and FIFO related all parameters.
+ *    @{
+*/
+
+/**
+ * @defgroup SEQID_Const
+ * @{
+*/
+#define SEQID_0                     0     /**< Sequence0 */
+#define SEQID_1                     1     /**< Sequence1 */
+#define SEQID_2                     2     /**< Sequence2 */
+#define SEQID_3                     3     /**< Sequence3 */
+/** @} */
+
+/**
+ * @defgroup SEQID_Const
+ * @brief Sequencer memory size. SRAM is shared between FIFO and Sequencer
+ * @warning The total available SRAM is 6kB. It's shared by FIFO and sequencer.
+ * @{
+*/
+#define SEQMEMSIZE_32B              0     /**< The selfbuild in 32Byte for sequencer. All 6kB SRAM  can be used for data FIFO */
+#define SEQMEMSIZE_2KB              1     /**< Sequencer use 2kB. The reset 4kB can be used for data FIFO */
+#define SEQMEMSIZE_4KB              2     /**< 4kB for Sequencer. 2kB for data FIFO */
+#define SEQMEMSIZE_6KB              3     /**< All 6kB for Sequencer. Build in 32Bytes memory can be used for data FIFO */
+/** @} */
+
+
+/* Mode of GPIO detecting used for triggering sequence */
+/**
+ * @defgroup SEQPINTRIGMODE_Const
+ * @{
+*/
+#define SEQPINTRIGMODE_RISING        0     /**< Rising edge */
+#define SEQPINTRIGMODE_FALLING       1     /**< Falling edge */
+#define SEQPINTRIGMODE_BOTHEDGE      2     /**< Rising or falling */
+#define SEQPINTRIGMODE_HIGHL         3     /**< High level */
+#define SEQPINTRIGMODE_LOWL          4     /**< Low level */
+/** @} */
+
+/* Sequencer helper */
+/**
+ * @defgroup Sequencer_Helper
+ * @{
+*/
+
+/* Three kinds of sequencer commands: wait, time-out, write */
+/* Decoded by BIT[31:30] */
+/** 
+ * Wait command. Wait some clocks-code Command Code: 'b00
+ * @warning Maximum wait time is 0x3fff_ffff/System clock.
+ */
+#define SEQ_WAIT(ClkNum)            (0x00000000| ((uint32_t)(ClkNum)&0x3fffffff))
+
+/** 
+ * Time-Out command. Set time-out count down value. Command Code: 'b01
+ * @warning maximum time-out timer value is 0x3fffffff 
+ * */
+#define SEQ_TOUT(ClkNum)            (0x40000000| ((uint32_t)(ClkNum)&0x3fffffff)) 
+
+/** 
+ * Write register command. Command Code: 'b10 or 'b11 
+ * @warning Address range is 0x2000 to 0x21FF. Data is limited to 24bit width.
+ * */
+#define SEQ_WR(addr,data)           (0x80000000|(((((uint32_t)(addr))>>2)&0x7f)<<24)  \
+                                        |(((uint32_t)(data))&0xffffff))
+
+/* Some commands used frequently */
+#define SEQ_NOP()                   SEQ_WAIT(0) /**< SEQ_NOP is just a simple wait command that wait one system clock */
+#define SEQ_HALT()                  SEQ_WR(REG_AFE_SEQCON,0x12)   /**< Can halt sequencer. Used for debug */
+#define SEQ_STOP()                  SEQ_WR(REG_AFE_SEQCON,0x00)   /**< Disable sequencer, this will generate End of Sequence interrupt */
+
+#define SEQ_SLP()                   SEQ_WR(REG_AFE_SEQTRGSLP, 1)  /**< Trigger sleep. If sleep is allowed, AFE will go to sleep/hibernate mode */
+
+#define SEQ_INT0()                  SEQ_WR(REG_AFE_AFEGENINTSTA, (1L<<0)) /**< Generate custom interrupt 0 */
+#define SEQ_INT1()                  SEQ_WR(REG_AFE_AFEGENINTSTA, (1L<<1)) /**< Generate custom interrupt 1 */
+#define SEQ_INT2()                  SEQ_WR(REG_AFE_AFEGENINTSTA, (1L<<2)) /**< Generate custom interrupt 2 */
+#define SEQ_INT3()                  SEQ_WR(REG_AFE_AFEGENINTSTA, (1L<<3)) /**< Generate custom interrupt 3 */
+
+/* Helper to calculate sequence length in array */
+#define SEQ_LEN(n)                  (sizeof(n)/4)   /**< Calculate how many commands are in sepecified array. */
+/** @} */ //Sequencer_Helper 
+
+/* FIFO */
+/**
+ * @defgroup FIFOMODE_Const
+ * @{
+*/
+#define FIFOMODE_FIFO               2     /**< Standard FIFO mode. If FIFO is full, reject all comming data and put FIFO to fault state, report interrupt if enabled */
+#define FIFOMODE_STREAM             3     /**< Stream mode. If FIFO is full, discard older data. Report FIFO full interrupt if enabled */
+/** @} */
+
+/**
+ * @defgroup FIFOSRC_Const
+ * @{
+*/
+#define FIFOSRC_SINC3               0     /**< SINC3 data */
+#define FIFOSRC_DFT                 2     /**< DFT real and imaginary part */
+#define FIFOSRC_SINC2NOTCH          3     /**< SINC2+NOTCH block. Notch can be bypassed, so SINC2 data can be feed to FIFO */
+#define FIFOSRC_VAR                 4     /**< Statistic variarance output */
+#define FIFOSRC_MEAN                5     /**< Statistic mean output */
+/** @} */
+
+/**
+ * @defgroup FIFO_Helper
+ * @{
+*/
+/**
+ * Method to identify FIFO channel ID:
+ * [31:25][24:23][22:16][15:0]
+ * [ ECC ][SEQID][CH_ID][DATA]
+ * 
+ * CH_ID: [22:16] 7bit in total:
+ *        xxxxx_xx
+ *        11111_xx    : DFT results
+ *        11110_xx    : Mean of statistic block
+ *        11101_xx    : Variance of statistic block
+ *        1xxxx_xx    : Notch filter result, where xxx_xx is the ADC MUX P settings(6bits of reg ADCCON[5:0]).
+ *        0xxxx_xx    : SINC3 filter result, where xxx_xx is the ADC MUX P settings(6bits of reg ADCCON[5:0]). 
+*/ 
+#define FIFO_SEQID(data)          ((((uint32_t)data)>>23)&0x3)   /**< Return seqid of this FIFO result */
+#define FIFO_ECC(data)            ((((uint32_t)data)>>25)&0x7f)  /**< Return ECC of this FIFO result */
+#define FIFO_CHANID(data)         ((((uint32_t)data)>>16)&0x7f)  /**< Return Channel ID */
+#define FIFOCHANID_MUXP(data)     ((((uint32_t)data)>>16)&0x3f)  /**< Return the ADC MUXP selection */
+
+#define ISCHANID_DFT(data)        ((((((uint32_t)data)>>18)&0x1f)==0x1f)?bTRUE:bFALSE)    /**< If the channel id is DFT */
+#define ISCHANID_MEAN(data)       ((((((uint32_t)data)>>18)&0x1f)==0x1e)?bTRUE:bFALSE)    /**< If the channel id is MEAN */
+#define ISCHANID_VAR(data)        ((((((uint32_t)data)>>18)&0x1f)==0x1d)?bTRUE:bFALSE)    /**< If the channel id is Variance */
+#define ISCHANID_SINC3(data)      ((((((uint32_t)data)>>18)&0x1f)< 0x10)?bTRUE:bFALSE)    /**< If the channel id is SINC3 */
+#define ISCHANID_NOTCH(data)      ((((((uint32_t)data)>>18)&0x1f)>=0x10)&&(((((uint32_t)data>>18)&0x1f) < 0x1d)?bTRUE:bFALSE)) /**< If the channel id is Notch  */
+/** @} */
+
+/**
+ * @defgroup FIFOSIZE_Const
+ * @brief Set FIFO size. 
+ * @warning The total available SRAM is 6kB. It's shared by FIFO and sequencer.
+ * @{
+*/
+#define FIFOSIZE_32B                0     /**< The selfbuild in 32Byte for data FIFO. All 6kB SRAM for sequencer */
+#define FIFOSIZE_2KB                1     /**< DATA FIFO use 2kB. The reset 4kB is used for sequencer */
+#define FIFOSIZE_4KB                2     /**< 4kB for Data FIFO. 2kB for sequencer */
+#define FIFOSIZE_6KB                3     /**< All 6kB for Data FIFO. Build in 32Bytes memory for sequencer */
+/** @} */
+
+/* Wake up timer */
+/**
+ * @defgroup WUPTENDSEQ_Const
+ * @{
+*/
+#define WUPTENDSEQ_A                0   /**< End at slot A */
+#define WUPTENDSEQ_B                1   /**< End at slot B */
+#define WUPTENDSEQ_C                2   /**< End at slot C */
+#define WUPTENDSEQ_D                3   /**< End at slot D */
+#define WUPTENDSEQ_E                4   /**< End at slot E */
+#define WUPTENDSEQ_F                5   /**< End at slot F */
+#define WUPTENDSEQ_G                6   /**< End at slot G */
+#define WUPTENDSEQ_H                7   /**< End at slot H */
+/** @} */
+
+/** 
+ * @} End of sequencer_and_FIFO block 
+ * @} Sequencer_FIFO
+ * */
+
+/**
+ * @addtogroup MISC_Block
+ * @{
+ *    @defgroup MISC_Block_Const
+ *    @brief This block includes clock, GPIO, configuration.
+ *    @{
+*/
+
+/* Helper for calculate clocks needed for various of data type */
+/**
+ * @defgroup DATATYPE_Const
+ * @{
+*/
+#define DATATYPE_ADCRAW             0     /**< ADC raw data */
+#define DATATYPE_SINC3              1     /**< SINC3 data */
+#define DATATYPE_SINC2              2     /**< SINC2 Data */
+#define DATATYPE_DFT                3     /**< DFT */
+#define DATATYPE_NOTCH              4     /**< Notch filter output. (when notch is not bypassed) */
+//#define DATATYPE_MEAN
+/** @} */
+
+
+/**
+ * @defgroup SLPKEY_Const
+ * @{
+*/
+#define SLPKEY_LOCK                 0       /**< any incorrect value will lock the key */
+#define SLPKEY_UNLOCK               0xa47e5 /**< The correct key for register SEQSLPLOCK */
+/** @} */
+
+/**
+ * @defgroup HPOSCOUT_Const
+ * @brief Set HPOSC output clock frequency, 16MHz or 32MHz.
+ * @{
+*/
+#define HPOSCOUT_32MHZ              0   /**< Configure internal HFOSC output 32MHz clock */
+#define HPOSCOUT_16MHZ              1   /**< 16MHz Clock */
+/** @} */
+
+/* GPIO */
+/**
+ * @defgroup AGPIOPIN_Const
+ * @brief The pin masks for register GP0OEN, GP0PE, GP0IEN,..., GP0TGL
+ * @{
+*/
+#define AGPIO_Pin0                  0x01  /**< AFE GPIO0, only available on AD5940 and AD5941, not ADuCM355 */
+#define AGPIO_Pin1                  0x02  /**< AFE GPIO1, only available on AD5940 and AD5941, not ADuCM355 */
+#define AGPIO_Pin2                  0x04  /**< AFE GPIO2, only available on AD5940 and AD5941, not ADuCM355 */
+#define AGPIO_Pin3                  0x08  /**< AFE GPIO3, only available on AD5941. */
+#define AGPIO_Pin4                  0x10  /**< AFE GPIO4, only available on AD5941. */
+#define AGPIO_Pin5                  0x20  /**< AFE GPIO5, only available on AD5941. */
+#define AGPIO_Pin6                  0x40  /**< AFE GPIO6, only available on AD5941. */
+#define AGPIO_Pin7                  0x80  /**< AFE GPIO7, only available on AD5941. */
+/** @} */
+
+/**
+ * @defgroup GP0FUNC_Const
+ * @{
+*/
+#define GP0_INT                     0        /**< Interrupt Controller 0 output */
+#define GP0_TRIG                    1        /**< Sequence0 trigger */
+#define GP0_SYNC                    2        /**< Use Sequencer to controll GP0 output level */
+#define GP0_GPIO                    3        /**< Normal GPIO function */
+/** @} */
+
+/**
+ * @defgroup GP1FUNC_Const
+ * @{
+*/  
+#define GP1_GPIO                    (0<<2)   /**< Normal GPIO function */
+#define GP1_TRIG                    (1<<2)   /**< Sequence1 trigger */
+#define GP1_SYNC                    (2<<2)   /**< Use Sequencer to controll GP1 output level */
+#define GP1_SLEEP                   (3<<2)   /**< Internal Sleep Signal */
+/** @} */
+
+/**
+ * @defgroup GP2FUNC_Const
+ * @{
+*/  
+#define GP2_PORB                    (0<<4)   /**< Internal Power ON reset signal */
+#define GP2_TRIG                    (1<<4)   /**< Sequence1 trigger */
+#define GP2_SYNC                    (2<<4)   /**< Use Sequencer to controll GP2 output level */
+#define GP2_EXTCLK                  (3<<4)   /**< External Clock input(32kHz/16MHz/32MHz) */
+/** @} */
+
+/**
+ * @defgroup GP3FUNC_Const
+ * @{
+*/  
+#define GP3_GPIO                    (0<<6)   /**< Normal GPIO function */
+#define GP3_TRIG                    (1<<6)   /**< Sequence3 trigger */
+#define GP3_SYNC                    (2<<6)   /**< Use Sequencer to controll GP3 output level */
+#define GP3_INT0                    (3<<6)   /**< Interrupt Controller 0 output */
+/** @} */
+
+/**
+ * @defgroup GP4FUNC_Const
+ * @note GP4 (Not available on AD5941)
+ * @{
+*/  
+#define GP4_GPIO                    (0<<8)   /**< Normal GPIO function */
+#define GP4_TRIG                    (1<<8)   /**< Sequence0 trigger */
+#define GP4_SYNC                    (2<<8)   /**< Use Sequencer to controll GP4 output level */
+#define GP4_INT1                    (3<<8)   /**< Interrupt Controller 1 output */
+/** @} */
+
+/**
+ * @defgroup GP5FUNC_Const
+ * @note GP5 (Not available on AD5941)
+ * @{
+*/  
+#define GP5_GPIO                    (0<<10)  /**< Internal Power ON reset signal */
+#define GP5_TRIG                    (1<<10)  /**< Sequence1 trigger */
+#define GP5_SYNC                    (2<<10)  /**< Use Sequencer to controll GP5 output level */
+#define GP5_EXTCLK                  (3<<10)  /**< External Clock input(32kHz/16MHz/32MHz) */
+/** @} */
+
+/**
+ * @defgroup GP6FUNC_Const
+ * @note GP6 (Not available on AD5941)
+ * @{
+*/  
+#define GP6_GPIO                    (0<<12)  /**< Normal GPIO function */
+#define GP6_TRIG                    (1<<12)  /**< Sequence2 trigger */
+#define GP6_SYNC                    (2<<12)  /**< Use Sequencer to controll GP6 output level */
+#define GP6_INT0                    (3<<12)  /**< Interrupt Controller 0 output */
+/** @} */
+
+/**
+ * @defgroup GP7FUNC_Const
+ * @note GP7 (Not available on AD5941)
+ * @{
+*/    
+#define GP7_GPIO                    (0<<14)  /**< Normal GPIO function */
+#define GP7_TRIG                    (1<<14)  /**< Sequence2 trigger */
+#define GP7_SYNC                    (2<<14)  /**< Use Sequencer to controll GP7 output level */
+#define GP7_INT                     (3<<14)  /**< Interrupt Controller 1 output */
+/** @} */
+
+//LPModeClk
+/**
+ * @defgroup LPMODECLK_Const
+ * @{
+*/ 
+#define LPMODECLK_HFOSC             0       /**< Use HFOSC 16MHz/32MHz clock as system clock */
+#define LPMODECLK_LFOSC             1       /**< Use LFOSC 32kHz clock as system clock */
+/** @} */
+
+/* Clock */
+/**
+ * @defgroup SYSCLKSRC_Const
+ * @brief Select system clock source. The clock must be available. If unavailable clock is selected, we can reset AD5940.
+ *        The system clock should be limited to 32MHz. If external clock or XTAL is faster than 16MHz, we use system clock divider to ensure it's always in range of 16MHz.
+ * @warning Maximum SPI clock has relation with system clock. Limit the SPI clock to ensure SPI clock is slower than system clock.
+ * @{
+*/
+#define SYSCLKSRC_HFOSC             0     /**< Internal HFOSC. CLock is 16MHz or 32MHz configurable. Set clock divider to ensure system clock is always 16MHz */
+#define SYSCLKSRC_XTAL              1     /**< External crystal. It can be 16MHz or 32MHz.Set clock divider to ensure system clock is always 16MHz */
+#define SYSCLKSRC_LFOSC             2     /**< Internal 32kHz clock. Note the SPI clock also sourced with 32kHz so the register read/write frequency is lower down. */
+#define SYSCLKSRC_EXT               3     /**< External clock from GPIO, AD594x Only */
+/** @} */
+
+/**
+ * @defgroup ADCCLKSRC_Const
+ * @brief Select ADC clock source.
+ *        The maximum clock is 32MHz.
+ * @warning The ADC raw data update rate is equal to ADCClock/20. When ADC clock is 32MHz, sample rate is 1.6MSPS.
+ *          The SINC3 filter clock are sourced from ADC clock and should be limited to 16MHz. When ADC clock is set to 32MHz. Clear bit ADCFILTERCON.BIT0 
+ *          to enable the SINC3 clock divider.
+ * @{
+*/
+#define ADCCLKSRC_HFOSC             0     /**< Internal HFOSC. 16MHz or 32MHz which is configurable */
+#define ADCCLKSRC_XTAL              1     /**< External crystal. Set ADC clock divider to get either 16MHz or 32MHz clock */
+//#define ADCCLKSRC_LFOSC             2     /**< Do not use */
+#define ADCCLKSRC_EXT               3     /**< External clock from GPIO. Set ADC clock divider to get the clock you want */
+/** @} */
+
+
+/**
+ * @defgroup ADCCLKDIV_Const
+ * @brief The divider for ADC clock. ADC clock = ClockSrc/Divider.
+ * @{
+*/
+#define ADCCLKDIV_1                 1     /**< Divider ADCClk = ClkSrc/1 */
+#define ADCCLKDIV_2                 2     /**< Divider ADCClk = ClkSrc/2 */
+/** @} */
+
+/**
+ * @defgroup SYSCLKDV_Const
+ * @brief The divider for system clock. System clock = ClockSrc/Divider.
+ * @{
+*/
+#define SYSCLKDIV_1                 1     /**< Divider SysClk = ClkSrc/1 */
+#define SYSCLKDIV_2                 2     /**< Divider SysClk = ClkSrc/2 */
+/** @} */
+
+/**
+ * @defgroup PGACALTYPE_Const
+ * @brief Calibration Type
+ * @{
+*/
+#define PGACALTYPE_OFFSET           0     /**< Calibrate offset */
+#define PGACALTYPE_GAIN             1     /**< Calibrate gain */
+#define PGACALTYPE_OFFSETGAIN       2     /**< Calibrate offset and gain */
+/** @} */
+
+/**
+ * @defgroup AD5940ERR_Const
+ * @brief AD5940 error code used by library and example codes.
+ * @{
+*/
+#define AD5940ERR_OK               0  /**< No error */
+#define AD5940ERR_ERROR           -1  /**< General error message */
+#define AD5940ERR_PARA            -2  /**< Parameter is illegal */ 
+#define AD5940ERR_NULLP           -3  /**< Null pointer */ 
+#define AD5940ERR_BUFF            -4  /**< Buffer limited. */
+#define AD5940ERR_ADDROR          -5  /**< Out of Range. Register address is out of range. */ 
+#define AD5940ERR_SEQGEN          -6  /**< Sequence generator error */ 
+#define AD5940ERR_SEQREG          -7  /**< Register info is not found */
+#define AD5940ERR_SEQLEN          -8  /**< Sequence length is too long. */
+#define AD5940ERR_WAKEUP          -9  /**< Unable to wakeup AFE in specified time */
+#define AD5940ERR_TIMEOUT         -10 /**< Time out error. */
+#define AD5940ERR_CALOR           -11 /**< calibration out of range. */
+#define AD5940ERR_APPERROR        -100  /**< Used in example code to indicated the application has not been initialized. */
+/** @} */
+
+#ifndef NULL
+  #define NULL      (void *) 0         /**< Null, if it's not defined. */
+#endif
+#define MATH_PI                   3.1415926f  /**< Pi defination. */
+
+#define AD5940_ADIID              0x4144      /**< ADIID is fixed to 0x4144 */
+#define AD5940_CHIPID             0x0000      /**< CHIPID is changing with silicon version */
+#define M355_ADIID                0x4144      /**< ADIID is fixed to 0x4144 */
+#define M355_CHIPID               0x0000      /**< CHIPID is changing with silicon version */
+
+#define AD5940_SWRST              0xa158      /**< AD594x only. The value to perform software reset via reigster SWRSTCON */
+#define KEY_OSCCON                0xcb14      /**< key of register OSCCON. The key is auto locked after writing to any other register */
+#define KEY_CALDATLOCK	          0xde87a5af  /**< Calibration key. */
+#define KEY_LPMODEKEY             0xc59d6     /**< LP mode key */
+
+#define PARA_CHECK(n)            /** add parameter check, Add DEBUG switch  */
+
+/** 
+ * @} MISC_Block_Const
+ * @} MISC_Block
+ * */
+/**
+ * @defgroup TypeDefinitions
+ * @{
+*/
+
+typedef int32_t AD5940Err;    /**< error number defination */
+
+/**
+ * bool definition for ad5940lib.
+*/
+typedef enum 
+{
+  bFALSE = 0, bTRUE = !bFALSE,   /**< True and False definition*/
+}BoolFlag;
+
+typedef struct
+{
+  /* ADC/DAC/TIA reference and buffer */
+  BoolFlag HpBandgapEn;     /**< Enable High power band-gap. Clear bit AFECON.HPREFDIS will enable Bandgap, while set this bit will disable bandgap */
+  BoolFlag Hp1V8BuffEn;     /**< High power 1.8V reference buffer enable */
+  BoolFlag Hp1V1BuffEn;     /**< High power 1.1V reference buffer enable */
+  BoolFlag Lp1V8BuffEn;     /**< Low power 1.8V reference buffer enable */
+  BoolFlag Lp1V1BuffEn;     /**< Low power 1.1V reference buffer enable */
+  /* Low bandwidth loop reference and buffer */
+  BoolFlag LpBandgapEn;     /**< Enable Low power band-gap. */
+  BoolFlag LpRefBufEn;      /**< Enable the 2.5V low power reference buffer */
+  BoolFlag LpRefBoostEn;    /**< Boost buffer current */
+  /* DAC Reference Buffer */
+  BoolFlag HSDACRefEn;      /**< Enable DAC reference buffer from HP Bandgap */
+  /* Misc. control  */
+  BoolFlag Hp1V8ThemBuff;   /**< Thermal Buffer for internal 1.8V reference to AIN3 pin  */              
+  BoolFlag Hp1V8Ilimit;     /**< Current limit for High power 1.8V reference buffer */
+  BoolFlag Disc1V8Cap;      /**< Discharge 1.8V capacitor. Short external 1.8V decouple capacitor to ground. Be careful when use this bit  */
+  BoolFlag Disc1V1Cap;      /**< Discharge 1.1V capacitor. Short external 1.1V decouple capacitor to ground. Be careful when use this bit  */
+}AFERefCfg_Type;
+
+/** 
+ * @defgroup ADC_BlockType
+ * @{
+*/
+
+/**
+ * Structure for ADC Basic settings include MUX and PGA.
+*/
+typedef struct
+{
+  uint32_t ADCMuxP;         /**< ADC Positive input channel selection. select from @ref ADCMUXP */
+  uint32_t ADCMuxN;         /**< ADC negative input channel selection. select from @ref ADCMUXN */
+  uint32_t ADCPga;          /**< ADC PGA settings, select from @ref ADCPGA */
+}ADCBaseCfg_Type;
+
+/**
+ * Structure for ADC filter settings.
+*/
+typedef struct
+{
+  uint32_t ADCSinc3Osr;
+  uint32_t ADCSinc2Osr;
+  uint32_t ADCAvgNum;           /**< Average filter is enabled when DFT source is @ref DFTSRC_AVG in function @ref AD5940_DFTCfgS. This average filter is only used by DFT engine. */
+  uint32_t ADCRate;             /**< ADC Core sample rate */
+  BoolFlag BpNotch;             /**< Bypass Notch filter in SINC2+Notch block, so only SINC2 is used. ADCFILTERCON.BIT4 */
+  BoolFlag BpSinc3;             /**< Bypass SINC3 Module */
+  BoolFlag Sinc2NotchEnable;    /**< Enable SINC2+Notch block */
+}ADCFilterCfg_Type;
+/** @} */
+
+/**
+ * DFT Configuration structure.
+*/
+typedef struct
+{
+  uint32_t DftNum;      /**< DFT number */
+  uint32_t DftSrc;      /**< DFT Source */
+  BoolFlag HanWinEn;    /**< Enable Hanning window */
+}DFTCfg_Type;
+
+/**
+ * ADC digital comparator
+*/
+typedef struct
+{
+  uint16_t ADCMin;      /**< The ADC code minimum limit value */
+  uint16_t ADCMinHys; 
+  uint16_t ADCMax;      /**< The ADC code maximum limit value */
+  uint16_t ADCMaxHys;   
+}ADCDigComp_Type;
+
+/**
+ * Statistic function
+*/
+typedef struct
+{
+  uint32_t StatDev;     /**< Statistic standard deviation configure */
+  uint32_t StatSample;  /**< Sample size */
+  BoolFlag StatEnable;  /**< Set true to enable statistic block */
+}StatCfg_Type;
+
+/**
+ * Switch matrix configure */
+typedef struct
+{
+  uint32_t Dswitch;  /**< D switch settings. Select from @ref SWD_Const*/
+  uint32_t Pswitch;  /**< P switch settings. Select from @ref SWP_Const */
+  uint32_t Nswitch;  /**< N switch settings. Select from @ref SWN_Const */
+  uint32_t Tswitch;  /**< T switch settings. Select from @ref SWT_Const */
+}SWMatrixCfg_Type;
+
+/** HSTIA Configure */
+typedef struct
+{
+  uint32_t HstiaBias;         /**< When select Vzero as bias, the related switch(VZERO2HSTIA) at LPDAC should be closed */
+  uint32_t HstiaRtiaSel;      /**< RTIA selection @ref HSTIARTIA_Const */
+  uint32_t HstiaCtia;         /**< Set internal CTIA value from 1 to 32 pF */
+  BoolFlag DiodeClose;        /**< Close the switch for internal back to back diode */
+  uint32_t HstiaDeRtia;       /**< DE0 node RTIA selection @ref HSTIADERTIA_Const */
+  uint32_t HstiaDeRload;      /**< DE0 node Rload selection @ref HSTIADERLOAD_Const */
+  uint32_t HstiaDe1Rtia;      /**< (ADuCM355 only, ignored on AD594x)DE1 node RTIA selection @ref HSTIADERTIA_Const */
+  uint32_t HstiaDe1Rload;     /**< (ADuCM355 only)DE1 node Rload selection @ref HSTIADERLOAD_Const */
+}HSTIACfg_Type;
+
+/** HSDAC Configure */
+typedef struct
+{
+  uint32_t ExcitBufGain;      /**< Select from  EXCITBUFGAIN_2, EXCITBUFGAIN_0P25 */     
+  uint32_t HsDacGain;         /**< Select from  HSDACGAIN_1, HSDACGAIN_0P2 */
+  uint32_t HsDacUpdateRate;   /**< Divider for DAC update. Available range is 7~255. */
+}HSDACCfg_Type;
+
+/** LPDAC Configure 
+ * @note The LPDAC structure:
+ * @code
+ * Switch to select DAC output to Vzero and Vbias nodes. Vzero and Vbias can select from DAC6BIT and DAC12BIT output freely. 
+ * LPDAC  >DAC6BIT ---- Vzero   LPDACVZERO_12BIT
+ *                 \--- Vbias   LPDACVBIAS_6BIT
+ *        >DAC12BIT---- Vzero   LPDACVZERO_6BIT
+ *                 \--- Vbias   LPDACVBIAS_12BIT
+ * Vzero/Vbias switch, controlled by @ref LPDACCfg_Type LpDacSW
+ * Vzero ------PIN
+ *       \-----LPTIA  LPDACSW_VZERO2LPTIA. LPTIA positive input
+ *        \----HSTIA  LPDACSW_VZERO2LPAMP. HSTIA positive input. Note, there is a MUX on HSTIA positive input pin to select the bias voltage between Vzero and 1.1V fixed internal reference.
+ * Vbias ------PIN    LPDACSW_VBIAS2PIN
+ *       \-----LPAMP  LPDACSW_VBIAS2LPAMP positive input. The potential state amplifier input, or called LPAMP or PA(potential amplifier).
+ * @endcode
+*/
+typedef struct
+{
+  uint32_t LpdacSel;        /**< Selectr from LPDAC0 or LPDAC1. LPDAC1 is only available on ADuCM355. */
+  uint32_t LpDacSrc;        /**< LPDACSRC_MMR or LPDACSRC_WG. Note: HSDAC is always connects to WG. Disable HSDAC if there is need. */
+  uint32_t LpDacVzeroMux;   /**< Select which DAC output connects to Vzero. 6Bit or 12Bit DAC */
+  uint32_t LpDacVbiasMux;   /**< Select which DAC output connects to Vbias */
+  uint32_t LpDacSW;         /**< LPDAC switch set. Only available from Si2 */
+  uint32_t LpDacRef;        /**< Reference selection. Either internal 2.5V LPRef or AVDD. select from @ref LPDACREF_Const*/
+  BoolFlag DataRst;         /**< Keep Reset register REG_AFE_LPDACDAT0DATA */
+  BoolFlag PowerEn;         /**< Power up REG_AFE_LPDACDAT0 */
+  uint16_t DacData12Bit;    /**< Data for 12bit DAC */
+  uint16_t DacData6Bit;     /**< Data for 6bit DAC */
+}LPDACCfg_Type;
+
+/**
+ * Low power amplifiers(PA and TIA)
+*/
+typedef struct
+{
+  uint32_t LpAmpSel;        /**< Select from LPAMP0 and LPAMP1. LPAMP1 is only available on ADuCM355. */
+  uint32_t LpTiaRf;         /**< The one order RC filter resistor selection. Select from @ref LPTIARF_Const */
+  uint32_t LpTiaRload;      /**< The Rload resistor right in front of LPTIA negative input terminal. Select from @ref LPTIARLOAD_Const*/
+  uint32_t LpTiaRtia;       /**< LPTIA RTIA resistor selection. Set it to open(@ref LPTIARTIA_Const) when use external resistor. */
+  uint32_t LpAmpPwrMod;     /**< Power mode for LP PA and LPTIA */
+  uint32_t LpTiaSW;         /**< Set of switches, using macro LPTIASW() to close switch */
+  BoolFlag LpPaPwrEn;       /**< Enable(bTRUE) or disable(bFALSE) power of PA(potential amplifier) */
+  BoolFlag LpTiaPwrEn;      /**< Enable(bTRUE) or Disable(bFALSE) power of LPTIA amplifier */
+}LPAmpCfg_Type;
+
+/**
+ * @brief Trapezoid Generator parameters
+ * The definition of the Trapezoid waveform is shown below. Note the Delay and Slope are all in clock unit.
+ * @code
+ * 
+ * DCLevel2         _________
+ *                 /         \
+ *                /           \
+ * DCLevel1 _____/             \______
+ *         |     |  |       |  |
+ *         Delay1|S1|Delay2 |S2| Delay1 repeat...
+ * Where S1 is slope1 and S2 is slop2
+ * @endcode
+ * The DAC update rate from Trapezoid generator is SystemClock/50. The default SystemClock
+ * is internal HFOSC 16MHz. So the update rate is 320kHz.
+ * The time parameter specifies in clock number.
+ * For example, if Delay1 is set to 10, S1 is set 20, the time for Delay1 period is 10/320kHz = 31.25us,
+ * and time for S1 period is 20/320kHz = 62.5us.
+*/
+typedef struct
+{
+  uint32_t WGTrapzDCLevel1;   /**< Trapezoid generator DC level1, this value is written directly to corresponding register */
+  uint32_t WGTrapzDCLevel2;   /**< DC level2, similar to DCLevel1 */
+  uint32_t WGTrapzDelay1;     /**< Trapezoid generator delay 1 */
+  uint32_t WGTrapzDelay2;     /**< Trapezoid generator delay 2 */
+  uint32_t WGTrapzSlope1;     /**< Trapezoid generator Slope 1 */
+  uint32_t WGTrapzSlope2;     /**< Trapezoid generator Slope 2 */
+}WGTrapzCfg_Type;
+
+/**
+ * Sin wave generator parameters
+*/
+typedef struct
+{
+  uint32_t SinFreqWord;       /**< Frequency word */
+  uint32_t SinAmplitudeWord;  /**< Amplitude word, range is 0 to 2047 */
+  uint32_t SinOffsetWord;     /**< Offset word, range is 0 to 4095 */
+  uint32_t SinPhaseWord;      /**< the start phase of sine wave. Use to tune start phase of signal. */
+}WGSinCfg_Type;
+
+/**
+ * Waveform generator configuration
+*/
+typedef struct
+{
+  uint32_t WgType;            /**< Select from WGTYPE_MMR, WGTYPE_SIN, WGTYPE_TRAPZ. HSDAC is always connected to WG. */
+  BoolFlag GainCalEn;         /**< Enable Gain calibration */
+  BoolFlag OffsetCalEn;       /**< Enable offset calibration */
+  WGTrapzCfg_Type TrapzCfg;   /**< Configure Trapezoid generator */
+  WGSinCfg_Type SinCfg;       /**< Configure Sine wave generator */
+  uint32_t WgCode;            /**< The 12bit data WG will move to DAC data register. */
+}WGCfg_Type;
+
+/**
+ * High speed loop configuration 
+ * */
+typedef struct
+{
+  SWMatrixCfg_Type SWMatCfg;  /**< switch matrix configuration. */
+  HSDACCfg_Type HsDacCfg;     /**< HSDAC configuration. */
+  WGCfg_Type WgCfg;           /**< Waveform generator configuration. */
+  HSTIACfg_Type HsTiaCfg;     /**< HSTIA configuration. */
+}HSLoopCfg_Type;
+
+/**
+ * Low power loop Configure 
+ * */
+typedef struct
+{
+  LPDACCfg_Type LpDacCfg;     /**< LPDAC configuration. @note Must select LPDAC0 or LPDAC1 in structure. */
+  LPAmpCfg_Type LpAmpCfg;     /**< LPAMP(LPTIA and PA) configuration. @note Must select LPAMP0 or LPAMP1 in structure. */
+}LPLoopCfg_Type;
+
+/**
+ * DSP Configure 
+ * */
+typedef struct
+{
+  ADCBaseCfg_Type ADCBaseCfg;       /**< ADC base configuration */
+  ADCFilterCfg_Type ADCFilterCfg;   /**< ADC filter configuration include SINC3/SINC2/Notch/Average(for DFT only) */
+  ADCDigComp_Type ADCDigCompCfg;    /**< ADC digital comparator */
+  DFTCfg_Type DftCfg;               /**< DFT configuration include data source, DFT number and Hanning Window */
+  StatCfg_Type StatCfg;             /**< Statistic block */
+}DSPCfg_Type;
+
+/**
+ * GPIO Configure 
+ * */
+typedef struct
+{
+  uint32_t FuncSet;         /**< AGP0 to AGP7 function sets */
+  uint32_t OutputEnSet;     /**< AGPIO_Pin0|AGPIO_Pin1|...|AGPIO_Pin7, Enable output of selected pins, disable other pins */
+  uint32_t InputEnSet;      /**< Enable input of selected pins, disable other pins */
+  uint32_t PullEnSet;       /**< Enable pull up or down on selected pin. disable other pins */
+  uint32_t OutVal;          /**< Value for GPIOOUT register */
+}AGPIOCfg_Type;
+
+/**
+ * FIFO configure
+*/
+typedef struct
+{
+  BoolFlag FIFOEn;          /**< Enable DATAFIFO. Disable FIFO will reset FIFO */
+  uint32_t FIFOMode;        /**< Stream mode or standard FIFO mode */
+  uint32_t FIFOSize;        /**< How to allocate the internal 6kB SRAM. Data FIFO and sequencer share all 6kB SRAM */
+  uint32_t FIFOSrc;         /**< Select which data source will be stored to FIFO */
+  uint32_t FIFOThresh;      /**< FIFO threshold value, 0 to 1023. Threshold can be used to generate interrupt so MCU can read back data before FIFO is full */
+}FIFOCfg_Type;
+
+/**
+ * Sequencer configure
+*/
+typedef struct
+{
+  uint32_t SeqMemSize;      /**< Sequencer memory size. SRAM is used by both FIFO and Sequencer. Make sure the total SRAM used is less than 6kB. */
+  BoolFlag SeqEnable;       /**< Enable sequencer. Only with valid trigger, sequencer can run */
+  BoolFlag SeqBreakEn;      /**< Do not use it */
+  BoolFlag SeqIgnoreEn;     /**< Do not use it */
+  BoolFlag SeqCntCRCClr;    /**< Clear sequencer count and CRC */
+  uint32_t SeqWrTimer;      /**< Set wait how much clocks after every commands executed */
+}SEQCfg_Type;
+
+/**
+ * Sequence info structure
+*/
+typedef struct
+{
+  uint32_t SeqId;           /**< The Sequence ID @ref SEQID_Const */
+  uint32_t SeqRamAddr;      /**< The start address that in AF5940 SRAM */
+  uint32_t SeqLen;          /**< Sequence length */
+  BoolFlag WriteSRAM;       /**< Write command to SRAM or not. */
+  const uint32_t *pSeqCmd;  /**< Pointer to the sequencer commands that stored in MCU */
+}SEQInfo_Type;
+
+typedef struct
+{
+  uint32_t PinSel;          /**< Select which pin are going to be configured. @ref AGPIOPIN_Const */
+  uint32_t SeqPinTrigMode;  /**< The pin detect mode. Select from @ref SEQPINTRIGMODE_Const */
+  BoolFlag bEnable;         /**< Allow detected pin action to trigger corresponding sequence. */
+}SeqGpioTrig_Cfg;
+
+/**
+ * Wakeup Timer Configure
+ * */
+typedef struct
+{
+  uint32_t WuptEndSeq;       /**<  end sequence selection @ref WUPTENDSEQ_Const. Wupt will go back to slot A after this one is executed. */
+  uint32_t WuptOrder[8];     /**<  The 8 slots for WakeupTimer. Place @ref SEQID_Const to this array. */
+  uint32_t SeqxSleepTime[4];  /**< Time before put AFE to sleep. 0 to 0x000f_ffff. We normally don't use this feature and it's disabled in @ref AD5940_Initialize */
+  uint32_t SeqxWakeupTime[4]; /**< Time before Wakeup AFE.  */
+  BoolFlag WuptEn;            /**< Timer enable. Once enabled, it starts to run. */
+}WUPTCfg_Type;
+
+/**
+ * Clock configure
+*/
+typedef struct
+{
+  uint32_t SysClkSrc;       /**< System clock source @ref SYSCLKSRC_Const */
+  uint32_t ADCCLkSrc;       /**< ADC clock source @ref ADCCLKSRC_Const */
+  uint32_t SysClkDiv;       /**< System clock divider. Use this to ensure System clock < 16MHz. */
+  uint32_t ADCClkDiv;       /**< ADC control clock divider. ADC core clock is @ADCCLkSrc, but control clock should be <16MHz.  */
+  BoolFlag HFOSCEn;         /**< Enable internal 16MHz/32MHz HFOSC */
+  BoolFlag HfOSC32MHzMode;  /**< Enable internal HFOSC to output 32MHz */
+  BoolFlag LFOSCEn;         /**< Enable internal 32kHZ OSC */
+  BoolFlag HFXTALEn;        /**< Enable XTAL driver */
+}CLKCfg_Type;
+
+/**
+ * HSTIA internal RTIA calibration structure
+ * @note ADC filter settings and DFT should be configured properly based on signal frequency.
+*/
+typedef struct
+{
+  float fFreq;                /**< Calibration frequency */
+  float fRcal;                /**< Rcal resistor value in Ohm*/
+  float SysClkFreq;           /**< The real frequency of system clock */  
+  float AdcClkFreq;           /**< The real frequency of ADC clock */   
+
+  HSTIACfg_Type HsTiaCfg;     /**< HSTIA configuration */
+  uint32_t ADCSinc3Osr;       /**< SINC3OSR_5, SINC3OSR_4 or SINC3OSR_2 */
+  uint32_t ADCSinc2Osr;       /**< SINC3OSR_5, SINC3OSR_4 or SINC3OSR_2 */ 
+  DFTCfg_Type DftCfg;         /**< DFT configuration. */
+  uint32_t bPolarResult;      /**< bTRUE-Polar coordinate:Return results in Magnitude and Phase. bFALSE-Cartesian coordinate: Return results in Real part and Imaginary Part */
+}HSRTIACal_Type;
+
+/**
+ * LPTIA internal RTIA calibration structure
+*/
+typedef struct
+{
+  float fFreq;                /**< Calibration frequency. Set it to 0.0 for DC calibration */
+  float fRcal;                /**< Rcal resistor value in Ohm*/
+  float SysClkFreq;           /**< The real frequency of system clock */  
+  float AdcClkFreq;           /**< The real frequency of ADC clock */   
+
+  uint32_t LpAmpSel;          /**< Select from LPAMP0 and LPAMP1. LPAMP1 is only available on ADuCM355. */
+  BoolFlag bWithCtia;         /**< Connect external CTIA or not. */
+  uint32_t LpTiaRtia;         /**< LPTIA RTIA selection. */
+  uint32_t LpAmpPwrMod;       /**< Amplifiers power mode setting */
+  uint32_t ADCSinc3Osr;       /**< SINC3OSR_5, SINC3OSR_4 or SINC3OSR_2 */
+  uint32_t ADCSinc2Osr;       /**< SINC3OSR_5, SINC3OSR_4 or SINC3OSR_2 */ 
+  DFTCfg_Type DftCfg;         /**< DFT configuration */
+  uint32_t bPolarResult;      /**< bTRUE-Polar coordinate:Return results in Magnitude and Phase. bFALSE-Cartesian coordinate: Return results in Real part and Imaginary Part */
+}LPRTIACal_Type;
+
+/**
+ * HSDAC calibration structure.
+*/
+typedef struct
+{
+  float fRcal;                /**< Rcal resistor value in Ohm*/
+  float SysClkFreq;           /**< The real frequency of system clock */  
+  float AdcClkFreq;           /**< The real frequency of ADC clock */ 
+
+  uint32_t AfePwrMode;        /**< Calibrate DAC in High power mode */
+  uint32_t ExcitBufGain;      /**< Select from  EXCITBUFGAIN_2, EXCITBUFGAIN_0P25 */     
+  uint32_t HsDacGain;         /**< Select from  HSDACGAIN_1, HSDACGAIN_0P2 */
+
+  uint32_t ADCSinc3Osr;       /**< SINC3OSR_5, SINC3OSR_4 or SINC3OSR_2 */
+  uint32_t ADCSinc2Osr;       /**< SINC3OSR_5, SINC3OSR_4 or SINC3OSR_2 */ 
+}HSDACCal_Type;
+
+/**
+ * LPDAC calibration structure.
+*/
+typedef struct
+{
+  uint32_t  LpdacSel;           /**< Select from LPDAC0 and LPDAC1. LPDAC1 is ADuCM355 only. */
+  float     SysClkFreq;         /**< The real frequency of system clock */  
+  float     AdcClkFreq;         /**< The real frequency of ADC clock */
+  float     ADCRefVolt;         /**< ADC reference voltage. Default is 1.82V*/
+  uint32_t  ADCSinc3Osr;        /**< SINC3OSR_5, SINC3OSR_4 or SINC3OSR_2 */
+  uint32_t  ADCSinc2Osr;        /**< SINC2 OSR settings. */ 
+  int32_t   SettleTime10us;     /**< Wait how much time after TIA is enabled? */   
+  int32_t   TimeOut10us;        /**< ADC converts signal need time. Specify the maximum time allowed. Timeout in 10us. negative number means wait no time. */
+}LPDACCal_Type;
+
+/**
+ * LPDAC parameters: LPDAC code to voltage transfer function.
+ * Voltage(mV) = kC2V_DACxB * Code + bC2V_DACxB; 
+ *  where x is 12 or 6 represent 12Bit DAC and 6Bit DAC. C2V means code to voltage.
+ *  Code is the data register value for LPDAC. The equation gives real output voltage of LPDAC.    
+ * Similarly, Code(LSB) = kV2C_DACxB * Voltage(mV) + bC2V_DAC12B;
+ * 
+ * Apparently, kV2C_DACxB = 1/kC2V_DACxB;
+ *             bC2V_DACxB = -bC2V_DACxB/kC2V_DACxB;
+*/
+typedef struct
+{
+  /* Code to voltage equation parameters */
+  float kC2V_DAC12B;        /**< the k factor of code to voltage(in mV) transfer function */
+  float bC2V_DAC12B;        /**< the offset of code to voltage transfer function. It's the voltage in mV when code is zero. */
+  float kC2V_DAC6B;         /**< the k factor for LPDAC 6 bit output. */
+  float bC2V_DAC6B;         /**< the offset for LPDAC 6 bit output. */
+ /* Code to voltage equation parameters */
+  float kV2C_DAC12B;        /**< the k factor for converting voltage to code for LPDAC 12bit output. */
+  float bV2C_DAC12B;        /**< the offset for converting voltage to code for LPDAC 12bit output. */
+  float kV2C_DAC6B;         /**< the k factor for converting voltage to code for LPDAC 6bit output. */
+  float bV2C_DAC6B;         /**< the offset for converting voltage to code for LPDAC 6bit output. */
+}LPDACPara_Type;
+
+/**
+ * LFOSC frequency measure structure
+*/
+typedef struct
+{
+  uint32_t CalSeqAddr;        /**< Sequence start address */
+  float CalDuration;          /**< Time can be used for calibration in unit of ms. Recommend to use tens of millisecond like 10ms */
+  float SystemClkFreq;        /**< System clock frequency.  */
+}LFOSCMeasure_Type;
+
+/**
+ * ADC PGA calibration type
+*/
+typedef struct
+{
+  float SysClkFreq;           /**< The real frequency of system clock */  
+  float AdcClkFreq;           /**< The real frequency of ADC clock */  
+  float VRef1p82;             /**< The real voltage of 1.82 reference. Unit is volt. */
+  float VRef1p11;             /**< The real voltage of 1.1 reference. Unit is volt. */
+  uint32_t ADCSinc3Osr;       /**< SINC3OSR_5, SINC3OSR_4 or SINC3OSR_2 */
+  uint32_t ADCSinc2Osr;       /**< SINC3OSR_5, SINC3OSR_4 or SINC3OSR_2 */ 
+  uint32_t ADCPga;            /**< Which PGA gain we are going to calibrate? */
+  uint32_t PGACalType;        /**< Calibrate gain of offset or gain+offset? */
+  int32_t TimeOut10us;        /**< Timeout in 10us. -1 means no time-out*/
+}ADCPGACal_Type;
+
+/**
+ * LPTIA Offset calibration type
+*/
+typedef struct
+{
+  uint32_t  LpAmpSel;           /**< Select from LPAMP0 and LPAMP1. LPAMP1 is only available on ADuCM355. */
+  float     SysClkFreq;         /**< The real frequency of system clock */  
+  float     AdcClkFreq;         /**< The real frequency of ADC clock */  
+  uint32_t  ADCSinc3Osr;        /**< SINC3OSR_5, SINC3OSR_4 or SINC3OSR_2 */
+  uint32_t  ADCSinc2Osr;        /**< SINC3OSR_5, SINC3OSR_4 or SINC3OSR_2 */ 
+  uint32_t  ADCPga;             /**< PGA Gain selection */
+  uint32_t  DacData12Bit;       /**< 12Bit DAC data */
+  uint32_t  DacData6Bit;        /**< 6Bit DAC data */
+  uint32_t  LpDacVzeroMux;      /**< Vzero is used as LPTIA bias voltage, select 12Bit/6Bit DAC */
+  uint32_t  LpAmpPwrMod;        /**< LP amplifiers power mode, select from LPAMPPWR_NORM, LPAMPPWR_BOOSTn*/ 
+  uint32_t  LpTiaSW;            /**< Switch configuration for LPTIA. Normally for SW(5) and SW(9).*/
+  uint32_t  LpTiaRtia;          /**< LPTIA RTIA resistor selection. */
+  int32_t   SettleTime10us;     /**< Wait how much time after TIA is enabled? */   
+  int32_t   TimeOut10us;        /**< ADC converts signal need time. Specify the maximum time allowed. Timeout in 10us. negative number means wait no time. */
+}LPTIAOffsetCal_Type;
+
+/**
+ * Structure for calculating how much system clocks needed for specified number of data
+*/
+typedef struct
+{
+  uint32_t DataType;          /**< The final data output selection. @ref DATATYPE_Const */
+  uint32_t DataCount;         /**< How many data you want. */
+  uint32_t ADCSinc3Osr;       /**< ADC SINC3 filter OSR setting */
+  uint32_t ADCSinc2Osr;       /**< ADC SINC2 filter OSR setting */
+  uint32_t ADCAvgNum;         /**< Average number for DFT engine. Only used when data type is DATATYPE_DFT and DftSrc is DFTSRC_AVG */
+  uint32_t DftSrc;            /**< The DFT source. Only used when data type is DATATYPE_DFT */
+  uint8_t  ADCRate;           /**< ADCRate @ref ADCRATE_Const. Only used when data type is DATATYPE_NOTCH */
+  BoolFlag BpNotch;           /**< Bypass notch filter or not. Only used when data type is DATATYPE_DFT and DftSrc is DFTSRC_SINC2NOTCH */
+  float RatioSys2AdcClk;      /**< Ratio of system clock to ADC clock frequency */
+}ClksCalInfo_Type;
+
+/** 
+ * Software controlled Sweep Function 
+ * */
+typedef struct
+{
+  BoolFlag SweepEn;         /**< Software can automatically sweep frequency from following parameters. Set value to 1 to enable it. */
+  float SweepStart;         /**< Sweep start frequency. Software will go back to the start frequency when it reaches SWEEP_STOP */
+  float SweepStop;          /**< Sweep end frequency. */
+  uint32_t SweepPoints;     /**< How many points from START to STOP frequency */
+  BoolFlag SweepLog;        /**< The step is linear or logarithmic. 0: Linear, 1: Logarithmic*/
+  uint32_t SweepIndex;      /**< Current position of sweep */
+}SoftSweepCfg_Type;
+
+/**
+ * Impedance result in Polar coordinate 
+*/
+typedef struct
+{
+  float Magnitude;         /**< The magnitude in polar coordinate */
+  float Phase;             /**< The phase in polar coordinate */
+}fImpPol_Type; //Polar
+
+/**
+ * Impedance result in Cartesian coordinate 
+*/
+typedef struct
+{
+  float Real;              /**< The real part in Cartesian coordinate */
+  float Image;             /**< The imaginary in Cartesian coordinate */
+}fImpCar_Type; //Cartesian
+
+/**
+ * int32_t type Impedance result in Cartesian coordinate 
+*/
+typedef struct
+{
+  int32_t Real;         /**< The real part in Cartesian coordinate */
+  int32_t Image;        /**< The real imaginary in Cartesian coordinate */
+}iImpCar_Type;
+
+/**
+ *  FreqParams_Type - Structure to store optimum filter settings 
+*/
+typedef struct
+{
+	BoolFlag HighPwrMode;
+	uint32_t DftNum;
+	uint32_t DftSrc;
+	uint32_t ADCSinc3Osr;
+	uint32_t ADCSinc2Osr;
+	uint32_t NumClks;
+}FreqParams_Type;
+
+/**
+ * @} TypeDefinitions
+*/
+
+/**
+ * @defgroup Exported_Functions
+ * @{
+*/
+/* 1. Basic SPI functions */
+void      AD5940_WriteReg(uint16_t RegAddr, uint32_t RegData);
+uint32_t  AD5940_ReadReg(uint16_t RegAddr);
+void      AD5940_FIFORd(uint32_t *pBuffer,uint32_t uiReadCount);
+
+/* 2. AD5940 Top Control functions */
+void      AD5940_Initialize(void); /* Call this function firstly once AD5940 power on or come from soft reset */
+void      AD5940_AFECtrlS(uint32_t AfeCtrlSet, BoolFlag State);
+AD5940Err AD5940_LPModeCtrlS(uint32_t EnSet);
+void      AD5940_AFEPwrBW(uint32_t AfePwr, uint32_t AfeBw); /* AFE power mode and system bandwidth control */
+void      AD5940_REFCfgS(AFERefCfg_Type *pBufCfg);
+
+/* 3. High_Speed_Loop Functions */
+void      AD5940_HSLoopCfgS(HSLoopCfg_Type *pHsLoopCfg);
+void      AD5940_SWMatrixCfgS(SWMatrixCfg_Type *pSwMatrix);
+void      AD5940_HSDacCfgS(HSDACCfg_Type *pHsDacCfg);
+AD5940Err AD5940_HSTIACfgS(HSTIACfg_Type *pHsTiaCfg);
+void      AD5940_HSRTIACfgS(uint32_t HSTIARtia);
+
+/* 4. Low_Power_Loop Functions*/
+void      AD5940_LPLoopCfgS(LPLoopCfg_Type *pLpLoopCfg);
+void      AD5940_LPDACCfgS(LPDACCfg_Type *pLpDacCfg);
+//void      AD5940_LPDACWriteS(uint16_t Data12Bit, uint8_t Data6Bit);
+void      AD5940_LPDAC0WriteS(uint16_t Data12Bit, uint8_t Data6Bit);
+void      AD5940_LPDAC1WriteS(uint16_t Data12Bit, uint8_t Data6Bit);
+void      AD5940_LPAMPCfgS(LPAmpCfg_Type *pLpAmpCfg);
+
+/* 5. DSP_Block_Functions */
+void      AD5940_DSPCfgS(DSPCfg_Type *pDSPCfg);
+uint32_t  AD5940_ReadAfeResult(uint32_t AfeResultSel);
+/* 5.1 ADC Block */
+void      AD5940_ADCBaseCfgS(ADCBaseCfg_Type *pADCInit);
+void      AD5940_ADCFilterCfgS(ADCFilterCfg_Type *pFiltCfg);
+void      AD5940_ADCPowerCtrlS(BoolFlag State);
+void      AD5940_ADCConvtCtrlS(BoolFlag State);
+void      AD5940_ADCMuxCfgS(uint32_t ADCMuxP, uint32_t ADCMuxN);
+void      AD5940_ADCDigCompCfgS(ADCDigComp_Type *pCompCfg);
+void      AD5940_StatisticCfgS(StatCfg_Type *pStatCfg);
+void      AD5940_ADCRepeatCfgS(uint32_t Number);
+void      AD5940_DFTCfgS(DFTCfg_Type *pDftCfg);
+/* 5.2 Waveform Generator Block */
+void      AD5940_WGCfgS(WGCfg_Type *pWGInit);
+AD5940Err AD5940_WGDACCodeS(uint32_t code); /* Directly write DAC Code */
+void      AD5940_WGFreqCtrlS(float SinFreqHz, float WGClock);
+uint32_t  AD5940_WGFreqWordCal(float SinFreqHz, float WGClock);
+//uint32_t AD5940_WGAmpWordCal(float Amp, BoolFlag DacGain, BoolFlag ExcitGain);
+
+/* 6. Sequencer_FIFO */
+void      AD5940_FIFOCfg(FIFOCfg_Type *pFifoCfg);
+AD5940Err AD5940_FIFOGetCfg(FIFOCfg_Type *pFifoCfg);  /* Read back current configuration */
+void      AD5940_FIFOCtrlS(uint32_t FifoSrc, BoolFlag FifoEn);   /* Configure FIFO data source. And disable/enable it.*/
+void      AD5940_FIFOThrshSet(uint32_t FIFOThresh);
+uint32_t  AD5940_FIFOGetCnt(void);     /* Get current FIFO count */
+void      AD5940_SEQCfg(SEQCfg_Type *pSeqCfg);
+AD5940Err AD5940_SEQGetCfg(SEQCfg_Type *pSeqCfg);    /* Read back current configuration */
+void      AD5940_SEQCtrlS(BoolFlag SeqEn);
+void      AD5940_SEQHaltS(void);
+void      AD5940_SEQMmrTrig(uint32_t SeqId); /* Manually trigger sequence */
+void      AD5940_SEQCmdWrite(uint32_t StartAddr, const uint32_t *pCommand, uint32_t CmdCnt);
+void      AD5940_SEQInfoCfg(SEQInfo_Type *pSeq);
+AD5940Err AD5940_SEQInfoGet(uint32_t SeqId, SEQInfo_Type *pSeqInfo);
+void      AD5940_SEQGpioCtrlS(uint32_t GpioSet);   /* Sequencer can control GPIO0~7 if the GPIO function is set to SYNC */
+uint32_t  AD5940_SEQTimeOutRd(void);  /* Read back current sequence time out value */
+AD5940Err AD5940_SEQGpioTrigCfg(SeqGpioTrig_Cfg *pSeqGpioTrigCfg);
+void      AD5940_WUPTCfg(WUPTCfg_Type *pWuptCfg);
+void      AD5940_WUPTCtrl(BoolFlag Enable);  /* Enable or disable Wakeup timer */
+AD5940Err AD5940_WUPTTime(uint32_t SeqId, uint32_t SleepTime, uint32_t WakeupTime);
+
+/* 7. MISC_Block */
+/* 7.1 Clock system */
+void      AD5940_CLKCfg(CLKCfg_Type *pClkCfg);
+void      AD5940_HFOSC32MHzCtrl(BoolFlag Mode32MHz);
+void 			AD5940_HPModeEn(BoolFlag Enable);	/* Switch system clocks to high power mode for EIS >80kHz)*/
+/* 7.2 AFE Interrupt */
+void      AD5940_INTCCfg(uint32_t AfeIntcSel, uint32_t AFEIntSrc, BoolFlag State);
+uint32_t  AD5940_INTCGetCfg(uint32_t AfeIntcSel);
+void      AD5940_INTCClrFlag(uint32_t AfeIntSrcSel);
+BoolFlag  AD5940_INTCTestFlag(uint32_t AfeIntcSel, uint32_t AfeIntSrcSel); /* Check if selected interrupt happened */
+uint32_t  AD5940_INTCGetFlag(uint32_t AfeIntcSel); /* Get current INTC interrupt flag */
+/* 7.3 GPIO */
+void      AD5940_AGPIOCfg(AGPIOCfg_Type *pAgpioCfg);
+void      AD5940_AGPIOFuncCfg(uint32_t uiCfgSet);
+void      AD5940_AGPIOOen(uint32_t uiPinSet);
+void      AD5940_AGPIOIen(uint32_t uiPinSet);
+uint32_t  AD5940_AGPIOIn(void);
+void      AD5940_AGPIOPen(uint32_t uiPinSet);
+void      AD5940_AGPIOSet(uint32_t uiPinSet);
+void      AD5940_AGPIOClr(uint32_t uiPinSet);
+void      AD5940_AGPIOToggle(uint32_t uiPinSet);
+
+/* 7.4 LPMODE */
+AD5940Err AD5940_LPModeEnS(BoolFlag LPModeEn); /* Enable LP mode or disable it. */
+void      AD5940_LPModeClkS(uint32_t LPModeClk);
+void      AD5940_ADCRepeatCfg(uint32_t Number);
+/* 7.5 Power */
+void      AD5940_SleepKeyCtrlS(uint32_t SlpKey); /* enter the correct key to allow AFE to enter sleep mode */
+void      AD5940_EnterSleepS(void);      /* Put AFE to hibernate/sleep mode and keep LP loop as the default settings. */
+void      AD5940_ShutDownS(void);    /* Unlock the key, turn off LP loop and enter sleep/hibernate mode  */
+uint32_t  AD5940_WakeUp(int32_t TryCount);   /* Try to wakeup AFE by read register */
+uint32_t  AD5940_GetADIID(void);   /* Read ADIID */
+uint32_t  AD5940_GetChipID(void);  /* Read Chip ID */
+AD5940Err AD5940_SoftRst(void);
+void      AD5940_HWReset(void);       /* Do hardware reset to AD5940 using RESET pin */
+/* Calibration functions */
+/* 8. Calibration */
+AD5940Err AD5940_ADCPGACal(ADCPGACal_Type *ADCPGACal);
+AD5940Err AD5940_LPDACCal(LPDACCal_Type *pCalCfg, LPDACPara_Type *pResult);
+AD5940Err AD5940_LPTIAOffsetCal(LPTIAOffsetCal_Type *pLPTIAOffsetCal);
+AD5940Err AD5940_HSRtiaCal(HSRTIACal_Type *pCalCfg, void *pResult);
+AD5940Err AD5940_HSDACCal(HSDACCal_Type *pCalCfg);
+AD5940Err AD5940_LPRtiaCal(LPRTIACal_Type *pCalCfg, void *pResult);
+AD5940Err AD5940_LFOSCMeasure(LFOSCMeasure_Type *pCfg, float *pFreq);
+//void      AD5940_LFOSCTrim(uint32_t TrimValue);  /* TrimValue: 0 to 15 */
+//void      AD5940_HFOSC16MHzTrim(uint32_t TrimValue);
+//void      AD5940_HFOSC32MHzTrim(uint32_t TrimValue);
+
+/* 9. Pure software functions. Functions with no register access. These functions are helpers */
+  /* Sequence Generator */
+void      AD5940_SEQGenInit(uint32_t *pBuffer, uint32_t BufferSize);/* Initialize sequence generator workspace */
+void      AD5940_SEQGenCtrl(BoolFlag bFlag);  /* Enable or disable sequence generator */
+void      AD5940_SEQGenInsert(uint32_t CmdWord); /* Manually insert a sequence command */
+AD5940Err AD5940_SEQGenFetchSeq(const uint32_t **ppSeqCmd, uint32_t *pSeqCount);  /* Fetch generated sequence and start a new sequence */
+void      AD5940_ClksCalculate(ClksCalInfo_Type *pFilterInfo, uint32_t *pClocks);
+uint32_t  AD5940_SEQCycleTime(void);
+void      AD5940_SweepNext(SoftSweepCfg_Type *pSweepCfg, float *pNextFreq);
+void      AD5940_StructInit(void *pStruct, uint32_t StructSize);
+float     AD5940_ADCCode2Volt(uint32_t code, uint32_t ADCPga, float VRef1p82); /* Calculate ADC code to voltage */
+BoolFlag  AD5940_Notch50HzAvailable(ADCFilterCfg_Type *pFilterInfo, uint8_t *dl);
+BoolFlag  AD5940_Notch60HzAvailable(ADCFilterCfg_Type *pFilterInfo, uint8_t *dl);
+fImpCar_Type AD5940_ComplexDivFloat(fImpCar_Type *a, fImpCar_Type *b);
+fImpCar_Type AD5940_ComplexMulFloat(fImpCar_Type *a, fImpCar_Type *b);
+fImpCar_Type AD5940_ComplexAddFloat(fImpCar_Type *a, fImpCar_Type *b);
+fImpCar_Type AD5940_ComplexSubFloat(fImpCar_Type *a, fImpCar_Type *b);
+
+fImpCar_Type AD5940_ComplexDivInt(iImpCar_Type *a, iImpCar_Type *b);
+fImpCar_Type AD5940_ComplexMulInt(iImpCar_Type *a, iImpCar_Type *b);
+float     AD5940_ComplexMag(fImpCar_Type *a);
+float     AD5940_ComplexPhase(fImpCar_Type *a);
+FreqParams_Type AD5940_GetFreqParameters(float freq);
+/**
+ * @} Exported_Functions
+*/
+
+/**
+ * @defgroup Library_Interface
+ *  The functions user should provide for specific MCU platform
+ * @{
+*/
+void      AD5940_CsClr(void);
+void      AD5940_CsSet(void);
+void      AD5940_RstClr(void);
+void      AD5940_RstSet(void);
+void      AD5940_Delay10us(uint32_t time);
+/* (Not used for now.)AD5940 has 8 GPIOs, some of them are connected to MCU. MCU can set or read the status of these pins. */
+void      AD5940_MCUGpioWrite(uint32_t data);   /*  */
+uint32_t  AD5940_MCUGpioRead(uint32_t);
+void      AD5940_MCUGpioCtrl(uint32_t, BoolFlag);
+void      AD5940_ReadWriteNBytes(unsigned char *pSendBuffer,unsigned char *pRecvBuff,unsigned long length);
+/* Below functions are frequently used in example code but not necessary for library */
+uint32_t  AD5940_GetMCUIntFlag(void);
+uint32_t  AD5940_ClrMCUIntFlag(void);
+uint32_t  AD5940_MCUResourceInit(void *pCfg);
+/**
+ * @} Library_Interface
+*/
+
+
+/**
+  * @} AD5940_Library
+  */
+
+#endif


### PR DESCRIPTION
BatImpedance_refactor_ad5940lib:
- added ad5940 source and header files designed for BatImpedance inside BatImpedance folder
- updated some values for BatImpedance configuration
- updated workspace file for BatImpedance example to use ad5940.c file at BatImpedance folder, not at ad5940lib folder
- added file path for preprocessor for BatImpedance example on the workspace file